### PR TITLE
Add User and Dev documentation with MkDocs

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -1,0 +1,28 @@
+name: deploy-documentation
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - uses: actions/cache@v3
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install mkdocs-material 
+      - run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -24,8 +24,16 @@ You can preview the production build with `npm run preview`.
 > To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
 
 # Resources
+
+## Front-end
 - [Jason Sturges - 3D with Svelte and Three.js](https://javascript.plainenglish.io/3d-with-svelte-and-three-js-f4366f342f9f)
 - [github.com/jasonsturges - Starter Svelte + Three.js project template](https://github.com/jasonsturges/threejs-sveltekit/tree/main)
 - [TypeScript types for three.js](https://github.com/three-types/three-ts-types)
 - [Typescript Classes](https://www.typescriptlang.org/docs/handbook/2/classes.html)
 - [Refactoring Guru - Design Patterns - Factory Method](https://refactoring.guru/design-patterns/factory-method)
+
+## Documentation
+- [MkDocs - static site generator for project documentation](https://www.mkdocs.org/)
+- [Material for MkDocs - documentation framework on top of MkDocs](https://squidfunk.github.io/mkdocs-material/)
+- [Material for MkDocs - Publishing your site - GitHub Pages](https://squidfunk.github.io/mkdocs-material/publishing-your-site/#with-github-actions)
+- [GitHub Docs - Configuring a publishing source for your GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)

--- a/docs/dev-guide/README.md
+++ b/docs/dev-guide/README.md
@@ -1,0 +1,3 @@
+# Developer Guide
+
+TODO

--- a/docs/dev-guide/README.md
+++ b/docs/dev-guide/README.md
@@ -1,3 +1,25 @@
 # Developer Guide
 
-TODO
+## Local deployment
+
+Install dependencies with:
+```bash
+npm install
+```
+
+Start a development server:
+
+```bash
+npm run dev
+
+# or start the server and open the app in a new browser tab
+npm run dev -- --open
+```
+
+## Building
+
+To create a production version of your app:
+
+```bash
+npm run build
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 # SiteVisor
+Digital Twin Application for Building Monitoring and Asset Management
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+# SiteVisor
+
+---
+
+SiteVisor is a Digital Twin ApplicaƟon for building monitoring and asset management, particularly for offices and industrial sites. The web applicatioon will simulate real world objects through a 3D digital twin, enabling users to see the site conditions, manage assets, and streamline maintenance tasks effectively.
+Check the [User Guide] to get started.
+
+[User Guide]: user-guide/README.md

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,0 +1,3 @@
+# User Guide
+
+TODO

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,3 +1,4 @@
 # User Guide
 
-TODO
+The user experience in the application is focused around the 3D viewer rendering a model of your facility.
+Use the tool sidebar to select different interaction options, such as creating a new room or adding a sensor.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -7,8 +7,9 @@ repo_url: https://github.com/grzpiotrowski/sitevisor
 edit_uri: blob/main/docs/
 
 nav:
-  - Home: index.md
+  - Overview: index.md
   - User Guide: user-guide/
   - Developer Guide: dev-guide/
 
-theme: readthedocs
+theme:
+  name: material

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,0 +1,14 @@
+site_name: SiteVisor
+site_url: https://example.com/
+site_description: Digital Twin application
+site_author: Grzegorz Piotrowski
+
+repo_url: https://github.com/grzpiotrowski/sitevisor
+edit_uri: blob/main/docs/
+
+nav:
+  - Home: index.md
+  - User Guide: user-guide/
+  - Developer Guide: dev-guide/
+
+theme: readthedocs


### PR DESCRIPTION
This PR adds documentation pages to the project.

The docs static pages are generated using [MkDocs](https://www.mkdocs.org/)

To test documentation locally start the server by running the `mkdocs serve` command.
Building the site is done with `mkdocs build` command.

The docs will be hosted on GitHub Pages.


TODO:
- [x] Write up the getting started docs.
- [x] Deploy docs on GitHub Pages

Closes #9, Closes #10 