### PR TITLE
Kafka connection

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,0 +1,2 @@
+VITE_BASE_URL=http://sitevisor.local:8080
+VITE_WEBSOCKET_URL=ws://sitevisor.local:8080/socket/out

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -24,10 +24,13 @@ nav:
   - Developer Guide:
     - Local deployment: dev-guide/local-deployment.md
     - Docker deployment: dev-guide/docker-deployment.md
-    - Kind deployment: dev-guide/kind-deployment.md
-    - Backend Kind deployment: sitevisor-backend/docs/deployment/kind-deployment.md
-    - Kafka deployment: sitevisor-backend/docs/deployment/kafka-deployment.md
-    - Kafka Websocket Proxy deployment: sitevisor-backend/docs/deployment/kafka-websocket-proxy-deployment.md
+    - Kind deployment:
+      - Kind Cluster: sitevisor-backend/docs/deployment/kind-cluster.md
+      - PostgreSQL deployment: sitevisor-backend/docs/deployment/postgres-deployment.md
+      - Backend deployment: sitevisor-backend/docs/deployment/kind-deployment.md
+      - Frontend deployment: dev-guide/kind-deployment.md
+      - Kafka deployment: sitevisor-backend/docs/deployment/kafka-deployment.md
+      - Kafka Websocket Proxy deployment: sitevisor-backend/docs/deployment/kafka-websocket-proxy-deployment.md
   - Architecture:
     - Architecture Overview: architecture/architecture-overview.md
     - Frontend Overview: architecture/architecture-frontend.md

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
-		"start": "export PORT=8080 && node ./build",
+		"start": "export PORT=3000 && node ./build",
 		"preview": "vite preview",
 		"test": "npm run test:integration && npm run test:unit",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/src/lib/assets/Sensor.ts
+++ b/src/lib/assets/Sensor.ts
@@ -11,7 +11,7 @@ export class Sensor extends Point3D {
   geometry: BoxGeometry;
   label: SensorLabel;
 
-  constructor(name: string, level: number, position: Vector3) {
+  constructor(name: string, device_id: string, level: number, position: Vector3) {
     super(position);
 
     this.geometry = new BoxGeometry(0.5, 0.5, 0.5);
@@ -24,13 +24,16 @@ export class Sensor extends Point3D {
     // Custom object properties
     this.userData = {
       name: name,
-      level: level
+      device_id: device_id,
+      level: level,
+      data: null
     };
 
     this.label = new SensorLabel(this.position, this);
   }
 
-  public update() {
+  public update(sensorData: { value: number, unit: string } = { value: 0, unit: '' }) {
+    this.userData.data = sensorData;
     this.label.update();
   }
 }

--- a/src/lib/assets/SensorLabel.ts
+++ b/src/lib/assets/SensorLabel.ts
@@ -15,21 +15,20 @@ export class SensorLabel extends CSS2DObject {
     this.sensor = sensor;
     this.element.style.marginTop = '-1em';
     this.sensorName = sensor.userData.name;
-    this.element.className = 'label';
-    this.element.id = "labelDivID";
+    this.element.className = 'sitevisor-sensor-label';
+    this.element.id = `sensor-label-${sensor.userData.device_id}`;
     this.element.innerHTML = `
                 <b> ${this.sensorName} </b>
                 `;
-                this.element.style.marginTop = '-1em';
-    
     this.position.set(position.x, position.y+0.7, position.z);
     this.layers.set(0);
   }
 
   public update() {
     this.element.innerHTML = `
-                <b> ${this.sensor.userData.name} </b>
-                `;
+        <b> ${this.sensor.userData.name} </b><br>
+        <b> ${this.sensor.userData.data.value} </b>
+`;
   } 
 
 }

--- a/src/lib/common/interfaces/ISensor.ts
+++ b/src/lib/common/interfaces/ISensor.ts
@@ -5,6 +5,7 @@ import { Vector3 } from "three";
  */
 export interface ISensor {
   name: string;
+  device_id: string;
   level: number;
   position: Vector3 | null;
 }

--- a/src/lib/components/AddSensorDialog.svelte
+++ b/src/lib/components/AddSensorDialog.svelte
@@ -1,17 +1,32 @@
 <script lang="ts">
     import { Viewer } from '$lib/viewer';
+	import { SitevisorService } from '../../services/sitevisor-service';
     import { newSensor } from '../../stores';
 	export let isDialogOpen: boolean;
     export let viewer: Viewer;
 
     let sensorDetails = {
-        name: ''
+        name: '',
+        device_id: '',
+        topic: ''
     };
+
+    let topics: string[] = [];
+
+    async function fetchTopics() {
+        topics = await SitevisorService.getTopics();
+    }
+
+    $: if (isDialogOpen) {
+        fetchTopics();
+    }
 
     function handleAddSensorSubmit() {
         // Update details in store but temporarily set position to null
         newSensor.update(() => (
-            { name: sensorDetails.name,
+            {
+                name: sensorDetails.name,
+                device_id: sensorDetails.device_id,
                 level: 0,
                 position: null,
             }
@@ -36,13 +51,18 @@
             bind:value={sensorDetails.name}>
         </div>
         <div class="form-control">
+            <label class="label" for="device_id">Sensor ID</label>
+            <input type="text" id="device_id" class="input input-bordered" required
+            bind:value={sensorDetails.device_id}>
+        </div>
+        <div class="form-control">
             <!-- TODO: Sensor fields -->
-            <label class="label" for="sensorType">Sensor Type</label>
-            <select id="sensorType" class="select select-bordered" required
-            >
-                <option value="" disabled selected>Select type</option>
-                <option value="temperature">Temperature</option>
-                <option value="humidity">Humidity</option>
+            <label class="label" for="sensorTopic">Sensor Topic</label>
+            <select id="sensorType" class="select select-bordered" bind:value={sensorDetails.topic} required>
+                <option value="" disabled selected>Select topic</option>
+                {#each topics as topic}
+                    <option value="{topic}">{topic}</option>
+                {/each}
             </select>
         </div>
         <div class="modal-action">

--- a/src/lib/utils/ObjectFactory.ts
+++ b/src/lib/utils/ObjectFactory.ts
@@ -46,10 +46,10 @@ export class ObjectFactory {
 
   createSensor(options: ISensor): Sensor | undefined {
     if (options.position != null) {
-      const sensor = new Sensor(options.name, options.level, options.position);
+      const sensor = new Sensor(options.name, options.device_id, options.level, options.position);
       this.scene.add(sensor);
       this.scene.add(sensor.label);
-      this.viewer.sensors.push(sensor);
+      this.viewer.sensors.set(sensor.userData.device_id, sensor);
       return sensor;
     }
     return undefined;

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -40,7 +40,7 @@ export class Viewer {
   private sensorInsertionMode: boolean = false;
   private roomInsertionPoints: Vector3[] = [];
 
-  public sensors: Sensor[] = [];
+  public sensors: Map<string, Sensor> = new Map();
   public rooms: Room[] = [];
 
   private tempRoomPreview: RoomPreview | null = null;
@@ -69,11 +69,12 @@ export class Viewer {
     const sensors = await SitevisorService.getSensors(this.projectId);
     sensors.forEach((sensor) => {
       const newSensor = new Sensor(sensor.name,
+        sensor.device_id,
         sensor.level,
         new Vector3(sensor.position?.x, sensor.position?.y, sensor.position?.z));
       this.scene.add(newSensor);
       this.scene.add(newSensor.label)
-      this.sensors.push(newSensor);
+      this.sensors.set(newSensor.userData.device_id, newSensor);
     });
   }
 

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -16,6 +16,7 @@
         const project: IProject = {
             id: -1,
             name: newProjectName,
+            kafka_topics: '',
             owner: user,
             rooms: [],
             sensors: []

--- a/src/routes/projects/[id]/manage/+page.svelte
+++ b/src/routes/projects/[id]/manage/+page.svelte
@@ -6,7 +6,9 @@
     import type { IProject } from "../../../../services/sitevisor-types";
 	export let data: PageData;
 
-    const project: IProject = data.project;
+    let project: IProject = data.project;
+    let updatedName = project.name;
+    let updatedKafkaTopics = project.kafka_topics;
 
     async function deleteProject() {
         try {
@@ -16,6 +18,24 @@
             console.log("Error trying to delete Project: " + project.id);
         }
     }
+
+    // Function to handle form submission
+    async function updateProject() {
+        const updatedProject = {
+            ...project,
+            name: updatedName,
+            kafka_topics: updatedKafkaTopics,
+        };
+
+        try {
+            await SitevisorService.updateProject(project.id.toString(), updatedProject);
+            project = updatedProject;
+            console.log("Project updated successfully");
+        } catch (error) {
+            console.error("Error updating project:", error);
+        }
+    }
+
 </script>
 
 <Header />
@@ -31,6 +51,23 @@
                 <a class="btn btn-primary" href="/projects/{project.id}/viewer">Digital Twin</a>
                 <button class="btn btn-error" on:click={deleteProject}>Delete</button>
             </div>
+        </div>
+    </div>
+    <div class="card bg-base-100 shadow-xl mt-4 w-1/2">
+        <div class="card-body">
+            <form on:submit|preventDefault={updateProject} class="form">
+                <div class="form-control">
+                    <label class="label" for="projectName">Project Name</label>
+                    <input class="input input-bordered" type="text" id="projectName" bind:value={updatedName}>
+                </div>
+                <div class="form-control">
+                    <label class="label" for="kafkaTopics">Kafka Topics</label>
+                    <input class="input input-bordered" type="text" id="kafkaTopics" bind:value={updatedKafkaTopics}>
+                </div>
+                <div class="card-actions justify-begin mt-4">
+                    <button type="submit" class="btn btn-primary">Update Project</button>
+                </div>
+            </form>
         </div>
     </div>
 </div>

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -24,7 +24,7 @@
         viewer.init(el, viewerContainer, project.id.toString());
         
         // WebSocket connection
-        const wsUrl = `${import.meta.env.VITE_WEBSOCKET_URL}?clientId=console_consumer&topic=my-topic`;
+        const wsUrl = `${import.meta.env.VITE_WEBSOCKET_URL}?clientId=console_consumer&topic=${project.kafka_topics}`;
         socket = new WebSocket(wsUrl);
 
         // WebSocket event listeners

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -33,8 +33,11 @@
         });
 
         socket.addEventListener('message', (event) => {
-            const message = event.data;
-            console.log('WebSocket message:', message);
+            const message = JSON.parse(event.data);
+            const sensorData = JSON.parse(message.value.value); // Double parse due to the structure
+            updateSensorData(sensorData.sensor_id, sensorData.data);
+
+            //console.log('WebSocket message:', message);
         });
 
         socket.addEventListener('close', (event) => {
@@ -45,6 +48,16 @@
             console.error('WebSocket error:', event);
         });
     });
+
+    function updateSensorData(device_id: string, newData: any) {
+    const sensor = viewer.sensors.get(device_id);
+    //console.log(sensor)
+    if (sensor) {
+        //sensor.userData.data = newData;
+        sensor.update(newData);
+        //console.log(sensor.userData.data);
+    }
+}
 
     function toggleRoomInsertion() {
         const roomInsertionMode: boolean = viewer.toggleRoomInsertionMode();

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -24,7 +24,7 @@
         viewer.init(el, viewerContainer, project.id.toString());
 
         // WebSocket connection
-        socket = new WebSocket('ws://localhost:8078/socket/out?clientId=console_consumer&topic=my-topic');
+        socket = new WebSocket('ws://sitevisor.local:8080/socket/out?clientId=console_consumer&topic=my-topic');
 
         // WebSocket event listeners
         socket.addEventListener('open', (event) => {

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -22,9 +22,10 @@
     onMount(() => {
         viewer = new Viewer();
         viewer.init(el, viewerContainer, project.id.toString());
-
+        
         // WebSocket connection
-        socket = new WebSocket('ws://sitevisor.local:8080/socket/out?clientId=console_consumer&topic=my-topic');
+        const wsUrl = `${import.meta.env.VITE_WEBSOCKET_URL}?clientId=console_consumer&topic=my-topic`;
+        socket = new WebSocket(wsUrl);
 
         // WebSocket event listeners
         socket.addEventListener('open', (event) => {

--- a/src/services/sitevisor-service.ts
+++ b/src/services/sitevisor-service.ts
@@ -6,7 +6,7 @@ import { loggedInUser } from "../stores";
 import { browser } from '$app/environment';
 
 export const SitevisorService = {
-	baseUrl: "http://localhost:4000",
+	baseUrl: "http://sitevisor.local:8080",
 
 	async getRooms(projectId: string): Promise<IRoom[]> {
 		try {

--- a/src/services/sitevisor-service.ts
+++ b/src/services/sitevisor-service.ts
@@ -8,6 +8,17 @@ import { browser } from '$app/environment';
 export const SitevisorService = {
 	baseUrl: import.meta.env.VITE_BASE_URL || "http://localhost:8080",
 
+	async getTopics(): Promise<string[]> {
+		try {
+			const response = await axios.get(this.baseUrl + `/api/kafka-proxy`);
+			//const response = await axios.get("http://localhost:8080" + `/topics`);
+			console.log(response.data)
+			return response.data;
+		} catch (error) {
+			return [];
+		}
+	},
+
 	async getRooms(projectId: string): Promise<IRoom[]> {
 		try {
 			const response = await axios.get(this.baseUrl + `/api/rooms/?project_id=${projectId}`);
@@ -49,6 +60,7 @@ export const SitevisorService = {
 		try {
             const sensorData = {
                 name: sensor.name,
+				device_id: sensor.device_id,
                 level: sensor.level,
                 position: { x: sensor.position?.x, y: sensor.position?.y, z: sensor.position?.z },
 				project: projectId

--- a/src/services/sitevisor-service.ts
+++ b/src/services/sitevisor-service.ts
@@ -99,6 +99,17 @@ export const SitevisorService = {
 		}
 	},
 
+	async updateProject(id: string, updatedProjectData: Partial<IProject>): Promise<void> {
+		try {
+			const url = `${this.baseUrl}/api/projects/${id}/`;
+			await axios.put(url, updatedProjectData);
+	
+			console.log("Project updated successfully");
+		} catch (error) {
+			console.error(`Error updating Project with id: ${id}`, error);
+		}
+	},
+
 	async createProject(project: IProject) {
 		try {
 			await axios.post(`${this.baseUrl}/api/projects/`, project);

--- a/src/services/sitevisor-service.ts
+++ b/src/services/sitevisor-service.ts
@@ -6,7 +6,7 @@ import { loggedInUser } from "../stores";
 import { browser } from '$app/environment';
 
 export const SitevisorService = {
-	baseUrl: "http://sitevisor.local:8080",
+	baseUrl: import.meta.env.VITE_BASE_URL || "http://localhost:8080",
 
 	async getRooms(projectId: string): Promise<IRoom[]> {
 		try {

--- a/src/services/sitevisor-types.ts
+++ b/src/services/sitevisor-types.ts
@@ -14,6 +14,7 @@ export interface IProject {
     id: number;
     name: string;
     owner: IUser;
+    kafka_topics: string;
     rooms: IRoom[];
     sensors: ISensor[];
 }


### PR DESCRIPTION
This PR focuses on realtime connection to Kafka cluster. This is done via Websocket connections.

The user can now configure each `Project` with a list of `topic` names. Then for each topic name, a websocket connection is opened and the data is extracted from messages and assigned to `Sensors` by their `devide_id`.

Also a Status indicator was added in the bottom right corner of the Digital Twin view, where the user can see which `topic` connections are active and reconnect if needed.

Also similar to the [PR #18](https://github.com/grzpiotrowski/sitevisor-backend/pull/18) in the backend - [nginx-ingress-controller](https://docs.nginx.com/nginx-ingress-controller/) is used to expose the app in the cluster with Ingress object.

![image](https://github.com/grzpiotrowski/sitevisor/assets/97438342/81b1b537-e589-4429-aa03-a665bf2a662b)

Closes #21, Closes #26, Closes #36
