### PR TITLE
Sensor interactivity and delete feature

### DIFF
--- a/src/lib/assets/Sensor.ts
+++ b/src/lib/assets/Sensor.ts
@@ -54,4 +54,12 @@ export class Sensor extends Point3D {
       this.label.element.style.visibility = 'hidden';
     }
   }
+
+  public setIsLabelVisible(isLabelVisible: boolean) {
+    if (isLabelVisible) {
+      this.label.element.style.visibility = 'visible';
+    } else {
+      this.label.element.style.visibility = 'hidden';
+    }
+  }
 }

--- a/src/lib/assets/Sensor.ts
+++ b/src/lib/assets/Sensor.ts
@@ -3,7 +3,7 @@ import {
     MeshStandardMaterial,
     Vector3,
   } from 'three';
-  import { Point3D } from './BaseTypes/Point3D';
+import { Point3D } from './BaseTypes/Point3D';
 import { SensorLabel } from './SensorLabel';
   
 export class Sensor extends Point3D {

--- a/src/lib/assets/Sensor.ts
+++ b/src/lib/assets/Sensor.ts
@@ -10,6 +10,7 @@ export class Sensor extends Point3D {
   material: MeshStandardMaterial;
   geometry: BoxGeometry;
   label: SensorLabel;
+  isSelected: boolean;
 
   constructor(name: string, device_id: string, level: number, position: Vector3) {
     super(position);
@@ -30,10 +31,27 @@ export class Sensor extends Point3D {
     };
 
     this.label = new SensorLabel(this.position, this);
+
+    this.isSelected = false;
   }
 
   public update(sensorData: { value: number, unit: string } = { value: 0, unit: '' }) {
     this.userData.data = sensorData;
     this.label.update();
+  }
+
+  public setIsSelected(isSelected: boolean) {
+    this.isSelected = isSelected;
+    if (isSelected) {
+      this.material = new MeshStandardMaterial({
+        color: 0x00ff00,
+      });
+      this.label.element.style.visibility = 'visible';
+    } else {
+      this.material = new MeshStandardMaterial({
+        color: 0xff0000,
+      });
+      this.label.element.style.visibility = 'hidden';
+    }
   }
 }

--- a/src/lib/assets/Sensor.ts
+++ b/src/lib/assets/Sensor.ts
@@ -12,7 +12,7 @@ export class Sensor extends Point3D {
   label: SensorLabel;
   isSelected: boolean;
 
-  constructor(name: string, device_id: string, level: number, position: Vector3) {
+  constructor(id: string, name: string, device_id: string, level: number, position: Vector3) {
     super(position);
 
     this.geometry = new BoxGeometry(0.5, 0.5, 0.5);
@@ -24,6 +24,7 @@ export class Sensor extends Point3D {
 
     // Custom object properties
     this.userData = {
+      id: id,
       name: name,
       device_id: device_id,
       level: level,

--- a/src/lib/assets/SensorLabel.ts
+++ b/src/lib/assets/SensorLabel.ts
@@ -27,8 +27,7 @@ export class SensorLabel extends CSS2DObject {
 
   public update() {
     this.element.innerHTML = `
-        <b> ${this.sensor.userData.name} </b><br>
-        <b> ${this.sensor.userData.data.value} </b>
+        <b> ${this.sensor.userData.name} </b>
         `;
   } 
 

--- a/src/lib/assets/SensorLabel.ts
+++ b/src/lib/assets/SensorLabel.ts
@@ -14,6 +14,7 @@ export class SensorLabel extends CSS2DObject {
     super(sensorDiv);
     this.sensor = sensor;
     this.element.style.marginTop = '-1em';
+    this.element.style.visibility = 'hidden';
     this.sensorName = sensor.userData.name;
     this.element.className = 'sitevisor-sensor-label';
     this.element.id = `sensor-label-${sensor.userData.device_id}`;
@@ -28,7 +29,7 @@ export class SensorLabel extends CSS2DObject {
     this.element.innerHTML = `
         <b> ${this.sensor.userData.name} </b><br>
         <b> ${this.sensor.userData.data.value} </b>
-`;
+        `;
   } 
 
 }

--- a/src/lib/common/interfaces/ISensor.ts
+++ b/src/lib/common/interfaces/ISensor.ts
@@ -4,6 +4,7 @@ import { Vector3 } from "three";
  * Interface representing the properties required to create a Sensor.
  */
 export interface ISensor {
+  id: string;
   name: string;
   device_id: string;
   level: number;

--- a/src/lib/components/AddSensorDialog.svelte
+++ b/src/lib/components/AddSensorDialog.svelte
@@ -24,7 +24,8 @@
     function handleAddSensorSubmit() {
         // Update details in store but temporarily set position to null
         newSensor.update(() => (
-            {
+            {   
+                id: '',
                 name: sensorDetails.name,
                 device_id: sensorDetails.device_id,
                 level: 0,

--- a/src/lib/components/AddSensorDialog.svelte
+++ b/src/lib/components/AddSensorDialog.svelte
@@ -5,6 +5,9 @@
 	export let isDialogOpen: boolean;
     export let viewer: Viewer;
 
+    let warningMessage = '';
+    let showWarning = false;
+
     let sensorDetails = {
         name: '',
         device_id: '',
@@ -22,6 +25,14 @@
     }
 
     function handleAddSensorSubmit() {
+        // Ensure device_id is unique
+        if (viewer.sensors.has(sensorDetails.device_id)) {
+            warningMessage = "A sensor with this ID already exists. Please use a unique ID.";
+            showWarning = true;
+            return;
+        } else {
+            showWarning = false;
+        }      
         // Update details in store but temporarily set position to null
         newSensor.update(() => (
             {   
@@ -43,7 +54,7 @@
 </script>
 
 <div class="modal" class:modal-open={isDialogOpen}>
-  <div class="modal-box">
+    <div class="modal-box">
     <h3 class="font-bold text-lg">Add Sensor</h3>
     <form on:submit|preventDefault={handleAddSensorSubmit}>
         <div class="form-control">
@@ -71,5 +82,13 @@
             <button type="button" class="btn" on:click={handleAddSensorCancelled}>Close</button>
         </div>
     </form>
-  </div>
+    {#if showWarning}
+        <div class="alert alert-warning shadow-lg mt-2">
+            <div>
+                <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current flex-shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.268 16c-.77 1.333.192 3 1.732 3z"/></svg>
+                <span>{warningMessage}</span>
+            </div>
+        </div>
+    {/if}
+    </div>
 </div>

--- a/src/lib/components/SensorDetails.svelte
+++ b/src/lib/components/SensorDetails.svelte
@@ -1,11 +1,23 @@
 <script lang="ts">
 	import type { Sensor } from "$lib/assets/Sensor";
 	import { selectedSensorStore } from "../../stores";
+  import { createEventDispatcher } from 'svelte';
+  import { SitevisorService } from "../../services/sitevisor-service";
 
   export let selectedSensor: Sensor | null;
+  let showSensorDeleteModal = false;
+  const dispatch = createEventDispatcher();
 
   function closeSensorDetails() {
     selectedSensorStore.set(null);
+  }
+
+  async function confirmDelete() {
+    if (selectedSensor) {
+      await SitevisorService.deleteSensor(selectedSensor.userData.id);
+      selectedSensorStore.set(null);
+      dispatch('removeSensor', { device_id: selectedSensor.userData.device_id });
+    }
   }
 
 </script>
@@ -17,5 +29,19 @@
   <p>Level: {selectedSensor?.userData.level}</p>
   {#if selectedSensor?.userData.data}
     <p>Reading: {selectedSensor?.userData.data.value} {selectedSensor?.userData.data.unit}</p>
+  {/if}
+  <button class="btn btn-error btn-sm" on:click={() => showSensorDeleteModal = true}>Delete Sensor</button>
+
+  {#if showSensorDeleteModal}
+    <div class="modal modal-open">
+      <div class="modal-box relative">
+        <h3 class="text-lg font-bold">Confirm Deletion</h3>
+        <p class="py-4">Are you sure you want to delete this sensor?</p>
+        <div class="modal-action">
+          <button class="btn" on:click={() => showSensorDeleteModal = false}>Cancel</button>
+          <button class="btn btn-error" on:click={confirmDelete}>Delete</button>
+        </div>
+      </div>
+    </div>
   {/if}
 </div>

--- a/src/lib/components/SensorDetails.svelte
+++ b/src/lib/components/SensorDetails.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
 	import type { Sensor } from "$lib/assets/Sensor";
+	import { selectedSensorStore } from "../../stores";
 
   export let selectedSensor: Sensor | null;
 
+  function closeSensorDetails() {
+    selectedSensorStore.set(null);
+  }
+
 </script>
 
-<div class="absolute top-0 right-0 mt-[70px] mr-4 p-4 bg-white shadow-md rounded-lg z-10">
-  <button class="absolute top-0 right-0 m-2" on:click={() => selectedSensor = null}>&times;</button>
+<div class="absolute top-0 right-0 mt-[70px] mr-4 p-4 bg-white shadow-md rounded-lg z-10 w-1/5">
+  <button class="absolute top-0 right-0 m-2" on:click={closeSensorDetails}>&times;</button>
   <h3 class="text-lg font-semibold">{selectedSensor?.userData.name}</h3>
   <p>ID: {selectedSensor?.userData.device_id}</p>
   <p>Level: {selectedSensor?.userData.level}</p>

--- a/src/lib/components/SensorDetails.svelte
+++ b/src/lib/components/SensorDetails.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type { Sensor } from "$lib/assets/Sensor";
+
+  export let selectedSensor: Sensor | null;
+
+</script>
+
+<div class="absolute top-0 right-0 mt-[70px] mr-4 p-4 bg-white shadow-md rounded-lg z-10">
+  <button class="absolute top-0 right-0 m-2" on:click={() => selectedSensor = null}>&times;</button>
+  <h3 class="text-lg font-semibold">{selectedSensor?.userData.name}</h3>
+  <p>ID: {selectedSensor?.userData.device_id}</p>
+  <p>Level: {selectedSensor?.userData.level}</p>
+  {#if selectedSensor?.userData.data}
+    <p>Reading: {selectedSensor?.userData.data.value} {selectedSensor?.userData.data.unit}</p>
+  {/if}
+</div>

--- a/src/lib/utils/ObjectFactory.ts
+++ b/src/lib/utils/ObjectFactory.ts
@@ -1,7 +1,7 @@
 import { Scene, Vector3 } from 'three';
 import { Room } from '../assets/Room';
 import { Sensor } from '$lib/assets/Sensor';
-import { newSensor, newRoom } from '../../stores';
+import { newRoom } from '../../stores';
 import { get } from "svelte/store";
 import type { IRoom } from '../common/interfaces/IRoom';
 import type { ISensor } from '$lib/common/interfaces/ISensor';
@@ -46,7 +46,7 @@ export class ObjectFactory {
 
   createSensor(options: ISensor): Sensor | undefined {
     if (options.position != null) {
-      const sensor = new Sensor(options.name, options.device_id, options.level, options.position);
+      const sensor = new Sensor(options.id, options.name, options.device_id, options.level, options.position);
       this.scene.add(sensor);
       this.scene.add(sensor.label);
       this.viewer.sensors.set(sensor.userData.device_id, sensor);
@@ -54,13 +54,6 @@ export class ObjectFactory {
     }
     return undefined;
     
-  }
-
-  createSensorAtPoint(sensorPosition: Vector3): ISensor {
-    const sensorData: ISensor = get(newSensor);
-    sensorData.position = sensorPosition;
-    this.createSensor(sensorData);
-    return sensorData;
   }
   
 }

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -186,7 +186,7 @@ export class Viewer {
     }
   }
 
-private setPointerPosition(event: MouseEvent) {
+  private setPointerPosition(event: MouseEvent) {
     const pos = this.getCanvasRelativePosition(event);
     this.pointer.x = (pos.x / this.canvasElement.clientWidth ) *  2 - 1;
     this.pointer.y = (pos.y / this.canvasElement.clientHeight) * -2 + 1;

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -13,6 +13,7 @@ import {
 import { CSS2DRenderer } from 'three/addons/renderers/CSS2DRenderer.js';
 import { Room } from './assets/Room';
 import { Sensor } from './assets/Sensor';
+import { selectedSensorStore } from '../stores';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { ReferencePlane } from './assets/ReferencePlane';
 import { PointerHelper } from './assets/PointerHelper';
@@ -179,6 +180,9 @@ export class Viewer {
     if (sensorIntersect) {
       const sensorObject = sensorIntersect.object as Sensor;
       sensorObject.label.element.style.visibility = 'visible';
+      this.handleSensorSelection(sensorObject);
+    } else {
+      this.handleSensorSelection(null);
     }
   }
 
@@ -225,6 +229,10 @@ private setPointerPosition(event: MouseEvent) {
         }
       }
     }
+  }
+
+  private handleSensorSelection(sensor: Sensor | null) {
+    selectedSensorStore.set(sensor);
   }
 
   private updateTempRoomPreview() {

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -174,9 +174,11 @@ export class Viewer {
     this.raycaster.setFromCamera( this.pointer, this.camera );
     const intersects = this.raycaster.intersectObjects( this.scene.children, false );
 
-    if ( intersects.length > 0 ) {
-      const intersected = intersects[0].object;
-      //console.log(intersected);
+    const sensorIntersect = intersects.find(intersect => intersect.object instanceof Sensor);
+
+    if (sensorIntersect) {
+      const sensorObject = sensorIntersect.object as Sensor;
+      sensorObject.label.element.style.visibility = 'visible';
     }
   }
 
@@ -269,6 +271,9 @@ private setPointerPosition(event: MouseEvent) {
   private animate = () => {
     requestAnimationFrame(this.animate);
     this.controls.update();
+    for (const [_, sensor] of this.sensors) {
+      sensor.label.element.style.visibility = 'hidden';
+    }
     this.checkPointerIntersection();
 
     const intersection = this.referencePlane.getIntersectionPoint(this.raycaster);

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -24,6 +24,7 @@ import { ObjectFactory } from './utils/ObjectFactory';
 
 import { SitevisorService } from '../services/sitevisor-service';
 import { RoomPreview } from './assets/RoomPreview';
+import { get } from 'svelte/store';
 
 export class Viewer {
   private projectId: string;
@@ -208,6 +209,7 @@ export class Viewer {
 
   private onCanvasClick(event: MouseEvent) {
     if (event.button === 0) { // Left mouse button clicked
+      // Handle interaction with the ReferencePlane
       const intersection = this.referencePlane.getIntersectionPoint(this.raycaster);
       if (intersection) {
         // console.log(`Intersection at: ${intersection.x}, ${intersection.y}, ${intersection.z}`);
@@ -234,11 +236,15 @@ export class Viewer {
           this.setSensorInsertionMode(false);
         }
       }
+
+      // Handle interaction with Sensors
+      this.getIntersectedSensor();
     }
   }
 
   private handleSensorSelection(sensor: Sensor | null) {
     selectedSensorStore.set(sensor);
+    sensor?.setIsSelected(true);
   }
 
   private updateTempRoomPreview() {
@@ -285,11 +291,15 @@ export class Viewer {
   private animate = () => {
     requestAnimationFrame(this.animate);
     this.controls.update();
+
+    // Update not selected sensors
     for (const [_, sensor] of this.sensors) {
-      sensor.label.element.style.visibility = 'hidden';
+      if (sensor != get(selectedSensorStore)){
+        sensor.setIsSelected(false);
+      }
     }
+
     this.checkPointerIntersection();
-    this.getIntersectedSensor();
 
     const intersection = this.referencePlane.getIntersectionPoint(this.raycaster);
     if (intersection) {

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -9,6 +9,9 @@ import {
   Raycaster,
   Vector2,
   Vector3,
+  Object3D,
+  type Intersection,
+  type Object3DEventMap,
 } from 'three';
 import { CSS2DRenderer } from 'three/addons/renderers/CSS2DRenderer.js';
 import { Room } from './assets/Room';
@@ -33,6 +36,7 @@ export class Viewer {
   private controls: OrbitControls;
   private raycaster: Raycaster;
   private pointer: Vector2;
+  private pointerIntersection: Intersection<Object3D<Object3DEventMap>>[];
   private referencePlane: ReferencePlane;
   private pointerHelper: PointerHelper;
 
@@ -173,9 +177,11 @@ export class Viewer {
 
   private checkPointerIntersection() {
     this.raycaster.setFromCamera( this.pointer, this.camera );
-    const intersects = this.raycaster.intersectObjects( this.scene.children, false );
+    this.pointerIntersection = this.raycaster.intersectObjects( this.scene.children, false );
+  }
 
-    const sensorIntersect = intersects.find(intersect => intersect.object instanceof Sensor);
+  private getIntersectedSensor() {
+    const sensorIntersect = this.pointerIntersection.find(intersect => intersect.object instanceof Sensor);
 
     if (sensorIntersect) {
       const sensorObject = sensorIntersect.object as Sensor;
@@ -183,7 +189,7 @@ export class Viewer {
       this.handleSensorSelection(sensorObject);
     } else {
       this.handleSensorSelection(null);
-    }
+    }  
   }
 
   private setPointerPosition(event: MouseEvent) {
@@ -283,6 +289,7 @@ export class Viewer {
       sensor.label.element.style.visibility = 'hidden';
     }
     this.checkPointerIntersection();
+    this.getIntersectedSensor();
 
     const intersection = this.referencePlane.getIntersectionPoint(this.raycaster);
     if (intersection) {

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -181,16 +181,15 @@ export class Viewer {
     this.pointerIntersection = this.raycaster.intersectObjects( this.scene.children, false );
   }
 
-  private getIntersectedSensor() {
+  private getIntersectedSensor(): Sensor | null {
     const sensorIntersect = this.pointerIntersection.find(intersect => intersect.object instanceof Sensor);
 
     if (sensorIntersect) {
       const sensorObject = sensorIntersect.object as Sensor;
-      sensorObject.label.element.style.visibility = 'visible';
-      this.handleSensorSelection(sensorObject);
+      return sensorObject;
     } else {
-      this.handleSensorSelection(null);
-    }  
+      return null;
+    }
   }
 
   private setPointerPosition(event: MouseEvent) {
@@ -238,13 +237,16 @@ export class Viewer {
       }
 
       // Handle interaction with Sensors
-      this.getIntersectedSensor();
+      const clickedSensor = this.getIntersectedSensor();
+      this.handleSensorSelection(clickedSensor);
     }
   }
 
   private handleSensorSelection(sensor: Sensor | null) {
+    if (sensor) {
+      sensor.setIsSelected(true);
+    }
     selectedSensorStore.set(sensor);
-    sensor?.setIsSelected(true);
   }
 
   private updateTempRoomPreview() {
@@ -292,6 +294,8 @@ export class Viewer {
     requestAnimationFrame(this.animate);
     this.controls.update();
 
+    this.checkPointerIntersection();
+
     // Update not selected sensors
     for (const [_, sensor] of this.sensors) {
       if (sensor != get(selectedSensorStore)){
@@ -299,7 +303,9 @@ export class Viewer {
       }
     }
 
-    this.checkPointerIntersection();
+    // Check Sensor mouseover
+    const sensorHoveredOver = this.getIntersectedSensor();
+    sensorHoveredOver?.setIsLabelVisible(true);
 
     const intersection = this.referencePlane.getIntersectionPoint(this.raycaster);
     if (intersection) {

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -160,7 +160,7 @@
 <div class="flex flex-col h-screen">
     <Header />
     {#if selectedSensor}
-        <SensorDetails selectedSensor={selectedSensor}/>
+        <SensorDetails on:removeSensor={e => viewer.removeSensorFromScene(e.detail.device_id)} selectedSensor={selectedSensor}/>
     {/if}
     <div class="flex flex-1 overflow-hidden">
         <div class="drawer lg:drawer-open">

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -7,6 +7,9 @@
     import AddRoomDialog from '$lib/components/AddRoomDialog.svelte';
     import type { PageData } from "../$types";
     import type { IProject } from "../../../../services/sitevisor-types";
+	import type { Sensor } from '$lib/assets/Sensor';
+	import { selectedSensorStore } from '../../../../stores';
+	import SensorDetails from '$lib/components/SensorDetails.svelte';
 	export let data: PageData;
 
     const project: IProject = data.project;
@@ -20,6 +23,7 @@
     let showWsStatuses: boolean = false;
     let addSensorDialogVisible: boolean = false;
     let addRoomDialogVisible: boolean = false;
+    let selectedSensor: Sensor | null = null;
     
     function getTopicNamesArray() {
         return project.kafka_topics ? project.kafka_topics.split(',') : [];
@@ -112,7 +116,11 @@
     onMount(() => {
         viewer = new Viewer();
         viewer.init(el, viewerContainer, project.id.toString());
-        
+
+        const unsubscribe = selectedSensorStore.subscribe(sensor => {
+            selectedSensor = sensor;
+        });
+
         initializeWebSockets();
     });
 
@@ -147,6 +155,9 @@
 
 <div class="flex flex-col h-screen">
     <Header />
+    {#if selectedSensor}
+        <SensorDetails selectedSensor={selectedSensor}/>
+    {/if}
     <div class="flex flex-1 overflow-hidden">
         <div class="drawer lg:drawer-open">
             <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -128,6 +128,10 @@
         const sensor = viewer.sensors.get(device_id);
         if (sensor) {
             sensor.update(newData);
+            // Reassign selectedSensor to trigger Svelte reactivity
+            if (sensor.userData.device_id === selectedSensor?.userData.device_id) {
+                selectedSensor = sensor;
+            }
         }
     }
 

--- a/src/services/sitevisor-service.ts
+++ b/src/services/sitevisor-service.ts
@@ -12,7 +12,6 @@ export const SitevisorService = {
 		try {
 			const response = await axios.get(this.baseUrl + `/api/kafka-proxy`);
 			//const response = await axios.get("http://localhost:8080" + `/topics`);
-			console.log(response.data)
 			return response.data;
 		} catch (error) {
 			return [];
@@ -22,7 +21,6 @@ export const SitevisorService = {
 	async getRooms(projectId: string): Promise<IRoom[]> {
 		try {
 			const response = await axios.get(this.baseUrl + `/api/rooms/?project_id=${projectId}`);
-			console.log(response.data)
 			return response.data;
 		} catch (error) {
 			return [];
@@ -56,7 +54,7 @@ export const SitevisorService = {
 		}
 	},
 
-	async createSensor(sensor: ISensor, projectId: string) {
+	async createSensor(sensor: ISensor, projectId: string): Promise<ISensor | undefined> {
 		try {
             const sensorData = {
                 name: sensor.name,
@@ -65,11 +63,24 @@ export const SitevisorService = {
                 position: { x: sensor.position?.x, y: sensor.position?.y, z: sensor.position?.z },
 				project: projectId
             };
-            await axios.post(`${this.baseUrl}/api/sensors/`, sensorData);
+            const response = await axios.post(`${this.baseUrl}/api/sensors/`, sensorData);
+			if (response.data) {
+				return response.data as Promise<ISensor>;
+			}
 		} catch (error) {
 			console.error("Error creating a Sensor", error);
+			return undefined;
 		}
-	  },
+	},
+
+	async deleteSensor(id: string): Promise<void> {
+		try {
+			await axios.delete(`${this.baseUrl}/api/sensors/${id}`);
+		} catch (error) {
+			console.error(`Error deleting Sensor with id ${id}`, error);
+			return;
+		}
+	},
 
 	async getProjects(): Promise<IProject[]> {
 		try {

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -2,9 +2,11 @@ import { writable } from "svelte/store";
 import type { LoggedInUser } from "./services/sitevisor-types";
 import type { ISensor } from "$lib/common/interfaces/ISensor";
 import type { IRoom } from "$lib/common/interfaces/IRoom";
+import type { Sensor } from "$lib/assets/Sensor";
 
 export const loggedInUser = writable<LoggedInUser>();
 
 // Local state for object creation
 export const newSensor = writable<ISensor>();
 export const newRoom = writable<IRoom>();
+export const selectedSensorStore = writable<Sensor | null>(null);


### PR DESCRIPTION
This PR introduces more interactivity with the Sensor object in the Viewer.

- Hover over the sensor to display its name
- Select sensor by clicking on it - highlights it in green
- View sensor details in a details window
- Delete sensor
- `device_id` sensor attribute is now required to be unique in the project when creating a new Sensor

Sensor creation was also refactored, now the POST request to the backend is made first and only if it's successful the new sensor is added to the scene. Previously it was the other way around.

![image](https://github.com/grzpiotrowski/sitevisor/assets/97438342/1e35aa2f-1a6c-43e2-aacd-5d8e45f0b56d)

Closes #16 
