### PR TITLE
Add Sensor pages

### DIFF
--- a/docs/dev-guide/local-deployment.md
+++ b/docs/dev-guide/local-deployment.md
@@ -12,6 +12,8 @@ Install dependencies with:
 npm install
 ```
 
+Set `VITE_BASE_URL` and `VITE_WEBSOCKET_URL` in .env file.
+
 Start a development server:
 
 ```bash

--- a/src/lib/assets/Sensor.ts
+++ b/src/lib/assets/Sensor.ts
@@ -12,7 +12,7 @@ export class Sensor extends Point3D {
   label: SensorLabel;
   isSelected: boolean;
 
-  constructor(id: string, name: string, device_id: string, level: number, position: Vector3) {
+  constructor(id: string, name: string, device_id: string, level: number, type: string, position: Vector3) {
     super(position);
 
     this.geometry = new BoxGeometry(0.5, 0.5, 0.5);
@@ -28,6 +28,7 @@ export class Sensor extends Point3D {
       name: name,
       device_id: device_id,
       level: level,
+      type: type,
       data: null
     };
 

--- a/src/lib/common/interfaces/ISensor.ts
+++ b/src/lib/common/interfaces/ISensor.ts
@@ -9,5 +9,11 @@ export interface ISensor {
   device_id: string;
   level: number;
   position: Vector3 | null;
-  type: string;
+  type: ISensorType;
+}
+
+export interface ISensorType {
+  id: number;
+  name: string;
+  project: number;
 }

--- a/src/lib/common/interfaces/ISensor.ts
+++ b/src/lib/common/interfaces/ISensor.ts
@@ -9,4 +9,5 @@ export interface ISensor {
   device_id: string;
   level: number;
   position: Vector3 | null;
+  type: string;
 }

--- a/src/lib/components/AddSensorDialog.svelte
+++ b/src/lib/components/AddSensorDialog.svelte
@@ -17,7 +17,7 @@
     let sensorTypes: string[] = [];
 
     async function fetchSensorTypes() {
-        sensorTypes = ['Temperature', 'Humidity']
+        sensorTypes = ['Temperature', 'Humidity'];
     }
 
     $: if (isDialogOpen) {

--- a/src/lib/components/AddSensorDialog.svelte
+++ b/src/lib/components/AddSensorDialog.svelte
@@ -2,8 +2,10 @@
     import { Viewer } from '$lib/viewer';
 	import { SitevisorService } from '../../services/sitevisor-service';
     import { newSensor } from '../../stores';
+    import type { ISensorType } from '../../services/sitevisor-types';
 	export let isDialogOpen: boolean;
     export let viewer: Viewer;
+    export let projectId: number;
 
     let warningMessage = '';
     let showWarning = false;
@@ -14,10 +16,10 @@
         type: ''
     };
 
-    let sensorTypes: string[] = [];
+    let sensorTypes: ISensorType[] = [];
 
     async function fetchSensorTypes() {
-        sensorTypes = ['Temperature', 'Humidity'];
+        sensorTypes = await SitevisorService.getSensorTypes(projectId.toString());
     }
 
     $: if (isDialogOpen) {
@@ -73,7 +75,7 @@
             <select id="sensorType" class="select select-bordered" bind:value={sensorDetails.type} required>
                 <option value="" disabled selected>Select type</option>
                 {#each sensorTypes as type}
-                    <option value="{type}">{type}</option>
+                    <option value="{type.name}">{type.name}</option>
                 {/each}
             </select>
         </div>

--- a/src/lib/components/AddSensorDialog.svelte
+++ b/src/lib/components/AddSensorDialog.svelte
@@ -11,17 +11,17 @@
     let sensorDetails = {
         name: '',
         device_id: '',
-        topic: ''
+        type: ''
     };
 
-    let topics: string[] = [];
+    let sensorTypes: string[] = [];
 
-    async function fetchTopics() {
-        topics = await SitevisorService.getTopics();
+    async function fetchSensorTypes() {
+        sensorTypes = ['Temperature', 'Humidity']
     }
 
     $: if (isDialogOpen) {
-        fetchTopics();
+        fetchSensorTypes();
     }
 
     function handleAddSensorSubmit() {
@@ -41,6 +41,7 @@
                 device_id: sensorDetails.device_id,
                 level: 0,
                 position: null,
+                type: sensorDetails.type,
             }
             ));
         isDialogOpen = false;
@@ -68,12 +69,11 @@
             bind:value={sensorDetails.device_id}>
         </div>
         <div class="form-control">
-            <!-- TODO: Sensor fields -->
-            <label class="label" for="sensorTopic">Sensor Topic</label>
-            <select id="sensorType" class="select select-bordered" bind:value={sensorDetails.topic} required>
-                <option value="" disabled selected>Select topic</option>
-                {#each topics as topic}
-                    <option value="{topic}">{topic}</option>
+            <label class="label" for="sensorType">Sensor Type</label>
+            <select id="sensorType" class="select select-bordered" bind:value={sensorDetails.type} required>
+                <option value="" disabled selected>Select type</option>
+                {#each sensorTypes as type}
+                    <option value="{type}">{type}</option>
                 {/each}
             </select>
         </div>

--- a/src/lib/components/HeaderProject.svelte
+++ b/src/lib/components/HeaderProject.svelte
@@ -1,3 +1,7 @@
+<script lang="ts">
+  export let projectid: string;
+</script>
+
 <header class="navbar bg-base-300">
     <div class="flex-1">
       <a class="btn btn-ghost text-xl" href="/">SiteVisor</a>
@@ -5,6 +9,8 @@
     <div class="flex-none">
       <ul class="menu menu-horizontal px-1">
         <li><a href="/projects">Projects</a></li>
+        <li><a href="/projects/{projectid}/viewer">Digital Twin</a></li>
+        <li><a href="/projects/{projectid}/sensorlist">Sensors</a></li>
         <li><a href="/logout">Logout</a></li>
       </ul>
     </div>

--- a/src/lib/components/HeaderWelcome.svelte
+++ b/src/lib/components/HeaderWelcome.svelte
@@ -1,4 +1,4 @@
-<header class="navbar bg-base-100">
+<header class="navbar bg-base-300">
     <div class="flex-1">
       <a class="btn btn-ghost text-xl" href="/">SiteVisor</a>
     </div>

--- a/src/lib/components/SensorDetails.svelte
+++ b/src/lib/components/SensorDetails.svelte
@@ -120,6 +120,7 @@
   <canvas bind:this={chartCanvas}></canvas>
   <p>ID: {selectedSensor?.userData.device_id}</p>
   <p>Level: {selectedSensor?.userData.level}</p>
+  <p>Type: {selectedSensor?.userData.type}</p>
   {#if selectedSensor?.userData.data}
     <p>Reading: {selectedSensor?.userData.data.value} {selectedSensor?.userData.data.unit}</p>
   {/if}

--- a/src/lib/components/SensorDetails.svelte
+++ b/src/lib/components/SensorDetails.svelte
@@ -123,6 +123,7 @@
   {#if selectedSensor?.userData.data}
     <p>Reading: {selectedSensor?.userData.data.value} {selectedSensor?.userData.data.unit}</p>
   {/if}
+  <a class="btn btn-sm" href="/sensors/{selectedSensor?.userData.id}">Details</a>
   <button class="btn btn-error btn-sm" on:click={() => showSensorDeleteModal = true}>Delete Sensor</button>
   {#if showSensorDeleteModal}
     <div class="modal modal-open">

--- a/src/lib/utils/ObjectFactory.ts
+++ b/src/lib/utils/ObjectFactory.ts
@@ -46,7 +46,7 @@ export class ObjectFactory {
 
   createSensor(options: ISensor): Sensor | undefined {
     if (options.position != null) {
-      const sensor = new Sensor(options.id, options.name, options.device_id, options.level, options.type, options.position);
+      const sensor = new Sensor(options.id, options.name, options.device_id, options.level, options.type.name, options.position);
       this.scene.add(sensor);
       this.scene.add(sensor.label);
       this.viewer.sensors.set(sensor.userData.device_id, sensor);

--- a/src/lib/utils/ObjectFactory.ts
+++ b/src/lib/utils/ObjectFactory.ts
@@ -46,7 +46,7 @@ export class ObjectFactory {
 
   createSensor(options: ISensor): Sensor | undefined {
     if (options.position != null) {
-      const sensor = new Sensor(options.id, options.name, options.device_id, options.level, options.position);
+      const sensor = new Sensor(options.id, options.name, options.device_id, options.level, options.type, options.position);
       this.scene.add(sensor);
       this.scene.add(sensor.label);
       this.viewer.sensors.set(sensor.userData.device_id, sensor);

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -81,6 +81,7 @@ export class Viewer {
         sensor.name,
         sensor.device_id,
         sensor.level,
+        sensor.type,
         new Vector3(sensor.position?.x, sensor.position?.y, sensor.position?.z));
       this.scene.add(newSensor);
       this.scene.add(newSensor.label)

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -134,6 +134,12 @@ export class Viewer {
     this.loadObjects();
   }
 
+  public setCameraAt(x: number, y: number, z: number) {
+        this.camera.position.set(x-3, y+5, z-3);
+        this.controls.target.set(x, y, z);
+        this.controls.update();
+  }
+
   public toggleRoomInsertionMode(): boolean {
     this.roomInsertionMode = !this.roomInsertionMode;
     if (this.roomInsertionMode) {

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -81,7 +81,7 @@ export class Viewer {
         sensor.name,
         sensor.device_id,
         sensor.level,
-        sensor.type,
+        sensor.type.name,
         new Vector3(sensor.position?.x, sensor.position?.y, sensor.position?.z));
       this.scene.add(newSensor);
       this.scene.add(newSensor.label)

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -32,7 +32,7 @@
   <div class="p-4">
     <div class="grid grid-cols-4 gap-10 p-4">
       {#each projects as project}
-        <div class="card w-96 bg-base-200 shadow-xl">
+        <div class="card bg-base-200 shadow-xl">
           <figure class="px-10 pt-10"><img src="https://placehold.co/300x400" alt="Project Image" class="rounded-xl"></figure>
           <div class="card-body">
             <h2 class="card-title">{project.name}</h2>
@@ -43,7 +43,7 @@
           </div>
         </div>
       {/each}
-      <div class="card w-96 bg-base-300 shadow-xl cursor-pointer" >
+      <div class="card bg-base-300 shadow-xl cursor-pointer" >
         <div class="card-body">
           <h2 class="card-title">New Project</h2>
           <input type="text" placeholder="Project name" class="input w-full max-w-xs" bind:value={newProjectName}/>

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import Header from "$lib/components/Header.svelte";
     import { SitevisorService } from "../../services/sitevisor-service";
-    import type { IProject, ISensorType } from "../../services/sitevisor-types";
+    import type { IProject } from "../../services/sitevisor-types";
+    import type { ISensorType } from "$lib/common/interfaces/ISensor";
     import { loggedInUser } from "../../stores";
     import type { PageData } from "./$types";
     export let data: PageData;

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Header from "$lib/components/Header.svelte";
     import { SitevisorService } from "../../services/sitevisor-service";
-    import type { IProject } from "../../services/sitevisor-types";
+    import type { IProject, ISensorType } from "../../services/sitevisor-types";
     import { loggedInUser } from "../../stores";
     import type { PageData } from "./$types";
     export let data: PageData;
@@ -21,8 +21,15 @@
             rooms: [],
             sensors: []
         };
-        await SitevisorService.createProject(project);
+        const newProject = await SitevisorService.createProject(project);
         newProjectName = "";
+
+        if (newProject) {
+          const defaultSensorType1: ISensorType = {id: -1, name: "Temperature", project: newProject.id}
+          const defaultSensorType2: ISensorType = {id: -1, name: "Humidity", project: newProject.id}
+          await SitevisorService.addSensorType(defaultSensorType1);
+          await SitevisorService.addSensorType(defaultSensorType2);
+        }
 
         projects = await SitevisorService.getProjects();
     }

--- a/src/routes/projects/+page.ts
+++ b/src/routes/projects/+page.ts
@@ -1,7 +1,8 @@
+import type { Load } from "@sveltejs/kit";
 import { SitevisorService } from "../../services/sitevisor-service";
 export const ssr = false;
 
-export const load = async () => {
+export const load: Load = async () => {
   SitevisorService.checkPageRefresh();
   const projects = await SitevisorService.getProjects();
   return {

--- a/src/routes/projects/[id]/manage/+page.svelte
+++ b/src/routes/projects/[id]/manage/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import Header from "$lib/components/Header.svelte";
+	import HeaderProject from "$lib/components/HeaderProject.svelte";
     import type { PageData } from "../$types";
     import { goto } from "$app/navigation";
 	import { SitevisorService } from "../../../../services/sitevisor-service";
@@ -38,7 +38,7 @@
 
 </script>
 
-<Header />
+<HeaderProject projectid={project.id.toString()}/>
 
 <div class="container mx-auto p-5">
     <div class="card bg-base-100 shadow-xl">

--- a/src/routes/projects/[id]/manage/+page.svelte
+++ b/src/routes/projects/[id]/manage/+page.svelte
@@ -3,7 +3,8 @@
     import type { PageData } from "./$types";
     import { goto } from "$app/navigation";
 	import { SitevisorService } from "../../../../services/sitevisor-service";
-    import type { IProject, ISensorType } from "../../../../services/sitevisor-types";
+    import type { IProject } from "../../../../services/sitevisor-types";
+    import type { ISensorType } from "$lib/common/interfaces/ISensor";
 	export let data: PageData;
 
     let project: IProject = data.project;

--- a/src/routes/projects/[id]/manage/+page.svelte
+++ b/src/routes/projects/[id]/manage/+page.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
 	import HeaderProject from "$lib/components/HeaderProject.svelte";
-    import type { PageData } from "../$types";
+    import type { PageData } from "./$types";
     import { goto } from "$app/navigation";
 	import { SitevisorService } from "../../../../services/sitevisor-service";
-    import type { IProject } from "../../../../services/sitevisor-types";
+    import type { IProject, ISensorType } from "../../../../services/sitevisor-types";
 	export let data: PageData;
 
     let project: IProject = data.project;
+    let sensorTypes: ISensorType[] = data.sensorTypes;
     let updatedName = project.name;
     let updatedKafkaTopics = project.kafka_topics;
+    let newSensorTypeName = '';
 
     async function deleteProject() {
         try {
@@ -36,6 +38,31 @@
         }
     }
 
+    async function deleteSensorType(id: number) {
+        try {
+            await SitevisorService.deleteSensorType(id.toString());
+            sensorTypes = sensorTypes.filter(sensorType => sensorType.id !== id);
+        } catch (error) {
+            console.error(`Error deleting sensor type with id ${id}`, error);
+        }
+    }
+
+    async function addSensorType() {
+        let sensorTypeData: ISensorType = {
+            id: -1,
+            name: newSensorTypeName,
+            project: project.id,
+        };
+        try {
+            const newSensorType = await SitevisorService.addSensorType(sensorTypeData);
+            if (newSensorType) {
+                sensorTypes = [...sensorTypes, newSensorType];
+                newSensorTypeName = '';
+            }
+        } catch (error) {
+            console.error(`Error adding sensor type: ${newSensorTypeName}`, error);
+        }
+    }
 </script>
 
 <HeaderProject projectid={project.id.toString()}/>
@@ -49,25 +76,60 @@
             <p>Number of Sensors: {project.sensors.length}</p>
             <div class="card-actions justify-end">
                 <a class="btn btn-primary" href="/projects/{project.id}/viewer">Digital Twin</a>
-                <button class="btn btn-error" on:click={deleteProject}>Delete</button>
+                <button class="btn btn-error" on:click={deleteProject}>Delete Project</button>
             </div>
         </div>
     </div>
-    <div class="card bg-base-100 shadow-xl mt-4 w-1/2">
-        <div class="card-body">
-            <form on:submit|preventDefault={updateProject} class="form">
-                <div class="form-control">
-                    <label class="label" for="projectName">Project Name</label>
-                    <input class="input input-bordered" type="text" id="projectName" bind:value={updatedName}>
-                </div>
-                <div class="form-control">
-                    <label class="label" for="kafkaTopics">Kafka Topics</label>
-                    <input class="input input-bordered" type="text" id="kafkaTopics" bind:value={updatedKafkaTopics}>
-                </div>
-                <div class="card-actions justify-begin mt-4">
-                    <button type="submit" class="btn btn-primary">Update Project</button>
-                </div>
-            </form>
+    <div class="grid grid-cols-2 gap-4">
+        <div class="card bg-base-100 shadow-xl mt-4">
+            <div class="card-body">
+                <form on:submit|preventDefault={updateProject} class="form">
+                    <div class="form-control">
+                        <label class="label" for="projectName">Project Name</label>
+                        <input class="input input-bordered" type="text" id="projectName" bind:value={updatedName}>
+                    </div>
+                    <div class="form-control">
+                        <label class="label" for="kafkaTopics">Kafka Topics</label>
+                        <input class="input input-bordered" type="text" id="kafkaTopics" bind:value={updatedKafkaTopics}>
+                    </div>
+                    <div class="card-actions justify-begin mt-4">
+                        <button type="submit" class="btn btn-primary">Update Project</button>
+                    </div>
+                </form>
+            </div>
         </div>
-    </div>
+        <!-- Sensor Types Management Table -->
+        <div class="card bg-base-100 shadow-xl mt-4">
+            <div class="card-body">
+                <h2 class="card-title">Sensor Types</h2>
+                <table class="table w-full">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Action</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {#each sensorTypes as sensorType}
+                        <tr>
+                            <td>{sensorType.name}</td>
+                            <td>
+                                <button class="btn btn-error btn-xs" on:click={() => deleteSensorType(sensorType.id)}>Delete</button>
+                            </td>
+                        </tr>
+                        {/each}
+                        <tr>
+                            <td>
+                                <input class="input input-bordered input-sm" type="text" bind:value={newSensorTypeName} placeholder="New Sensor Type"/>
+                            </td>
+                            <td>
+                                <button class="btn btn-primary btn-xs" on:click={addSensorType}>Create</button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        </div>
+
 </div>

--- a/src/routes/projects/[id]/manage/+page.ts
+++ b/src/routes/projects/[id]/manage/+page.ts
@@ -1,10 +1,14 @@
+import type { Load } from "@sveltejs/kit";
 import { SitevisorService } from "../../../../services/sitevisor-service";
 export const ssr = false;
 
-export const load = async ({ params }) => {
+export const load: Load = async ({ params }) => {
   SitevisorService.checkPageRefresh();
-  const project = await SitevisorService.getProjectById(encodeURI(params.id));
+  const projectId = params.id ?? ''; 
+  const project = await SitevisorService.getProjectById(encodeURI(projectId));
+  const sensorTypes = await SitevisorService.getSensorTypes(encodeURI(projectId));
   return {
     project: project,
+    sensorTypes: sensorTypes,
   };
 };

--- a/src/routes/projects/[id]/sensorlist/+page.svelte
+++ b/src/routes/projects/[id]/sensorlist/+page.svelte
@@ -2,8 +2,8 @@
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import type { PageData } from './$types';
-  import type { ISensor } from '../../../../lib/common/interfaces/ISensor';
-  import type { IProject, ISensorType } from '../../../../services/sitevisor-types';
+  import type { ISensor, ISensorType } from '../../../../lib/common/interfaces/ISensor';
+  import type { IProject } from '../../../../services/sitevisor-types';
   import HeaderProject from '$lib/components/HeaderProject.svelte';
 	import { SitevisorService } from '../../../../services/sitevisor-service';
 	import type { Vector3 } from 'three';
@@ -28,7 +28,6 @@
 
   async function fetchSensorsByType() {
     if (selectedSensorTypeId) {
-      console.log(selectedSensorTypeId)
       sensors = await SitevisorService.getSensors(project.id.toString(), selectedSensorTypeId);
     } else {
       sensors = await SitevisorService.getSensors(project.id.toString());
@@ -90,7 +89,7 @@
         <tr>
           <td>{sensor.name}</td>
           <td>{sensor.device_id}</td>
-          <td>{sensor.type}</td>
+          <td>{sensor.type.name}</td>
           <td>{sensor.level}</td>
           <td>{sensor.position?.x.toFixed(2)}, {sensor.position?.y.toFixed(2)}, {sensor.position?.z.toFixed(2)}</td>
           <td>

--- a/src/routes/projects/[id]/sensorlist/+page.svelte
+++ b/src/routes/projects/[id]/sensorlist/+page.svelte
@@ -4,15 +4,37 @@
   import type { ISensor } from '../../../../lib/common/interfaces/ISensor';
   import type { IProject } from '../../../../services/sitevisor-types';
   import HeaderProject from '$lib/components/HeaderProject.svelte';
+	import { SitevisorService } from '../../../../services/sitevisor-service';
   export let data: PageData;
 
   let project: IProject = data.project;
 
   let sensors: ISensor[] = project.sensors;
 
+  let pendingDeleteSensorId: string | null = null;
+  let showSensorDeleteModal: boolean = false;
+
   onMount(() => {
     sensors = project.sensors;
   });
+
+  function confirmDelete(sensorId: string) {
+    pendingDeleteSensorId = sensorId;
+    showSensorDeleteModal = true;
+  }
+
+  async function deleteSensor() {
+    if (pendingDeleteSensorId) {
+      try {
+        await SitevisorService.deleteSensor(pendingDeleteSensorId);  
+        sensors = sensors.filter(s => s.id !== pendingDeleteSensorId);
+        showSensorDeleteModal = false;
+        pendingDeleteSensorId = null;
+      } catch (error) {
+        console.error("Error deleting sensor", error);
+      }
+    }
+  }
 </script>
 
 <HeaderProject projectid={project.id.toString()}/>
@@ -25,6 +47,7 @@
         <th>Device ID</th>
         <th>Level</th>
         <th>Position</th>
+        <th></th>
       </tr>
     </thead>
     <tbody>
@@ -34,9 +57,24 @@
           <td>{sensor.device_id}</td>
           <td>{sensor.level}</td>
           <td>{sensor.position?.x.toFixed(2)}, {sensor.position?.y.toFixed(2)}, {sensor.position?.z.toFixed(2)}</td>
+          <td>
+            <button class="btn btn-error btn-xs" on:click={() => confirmDelete(sensor.id)}>Delete</button>
+          </td>
         </tr>
       {/each}
     </tbody>
   </table>
+  {#if showSensorDeleteModal}
+    <div class="modal modal-open">
+      <div class="modal-box">
+        <h3 class="text-lg font-bold">Confirm Deletion</h3>
+        <p>Are you sure you want to delete this sensor?</p>
+        <div class="modal-action">
+          <button class="btn" on:click={() => showSensorDeleteModal = false}>Cancel</button>
+          <button class="btn btn-error" on:click={deleteSensor}>Delete</button>
+        </div>
+      </div>
+    </div>  
+  {/if}
 </div>
   

--- a/src/routes/projects/[id]/sensorlist/+page.svelte
+++ b/src/routes/projects/[id]/sensorlist/+page.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { PageData } from "../$types";
+  import type { ISensor } from '../../../../lib/common/interfaces/ISensor';
+  import type { IProject } from '../../../../services/sitevisor-types';
+  import HeaderProject from '$lib/components/HeaderProject.svelte';
+  export let data: PageData;
+
+  let project: IProject = data.project;
+
+  let sensors: ISensor[] = project.sensors;
+
+  onMount(() => {
+    sensors = project.sensors;
+  });
+</script>
+
+<HeaderProject projectid={project.id.toString()}/>
+
+<div class="container mx-auto p-5">
+  <table class="table w-full table-zebra">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Device ID</th>
+        <th>Level</th>
+        <th>Position</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each sensors as sensor}
+        <tr>
+          <td>{sensor.name}</td>
+          <td>{sensor.device_id}</td>
+          <td>{sensor.level}</td>
+          <td>{sensor.position?.x.toFixed(2)}, {sensor.position?.y.toFixed(2)}, {sensor.position?.z.toFixed(2)}</td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>
+  

--- a/src/routes/projects/[id]/sensorlist/+page.svelte
+++ b/src/routes/projects/[id]/sensorlist/+page.svelte
@@ -10,15 +10,31 @@
   export let data: PageData;
 
   let project: IProject = data.project;
-
-  let sensors: ISensor[] = project.sensors;
+  let sensors: ISensor[] = [];
+  let sensorTypes: string[] = [];
+  let selectedSensorType: string = "";
 
   let pendingDeleteSensorId: string | null = null;
   let showSensorDeleteModal: boolean = false;
 
   onMount(() => {
-    sensors = project.sensors;
+    fetchSensorTypes();
+    fetchSensorsByType();
   });
+
+  async function fetchSensorTypes() {
+    sensorTypes = ['Temperature', 'Humidity'];
+  }
+
+  async function fetchSensorsByType() {
+    if (selectedSensorType) {
+      sensors = await SitevisorService.getSensors(project.id.toString(), selectedSensorType);
+    } else {
+      sensors = await SitevisorService.getSensors(project.id.toString());
+    }
+  }
+
+  $: fetchSensorsByType(), selectedSensorType;
 
   function confirmDelete(sensorId: string) {
     pendingDeleteSensorId = sensorId;
@@ -48,6 +64,15 @@
 <HeaderProject projectid={project.id.toString()}/>
 
 <div class="container mx-auto p-5">
+  <div class="mb-4 flex items-center">
+    <label class="label mr-3" for="sensorTypeSelect">Sensor Type: </label>
+    <select id="sensorTypeSelect" class="select select-sm" bind:value={selectedSensorType} required>
+      <option selected value="">All</option>
+      {#each sensorTypes as type}
+        <option value={type}>{type}</option>
+      {/each}
+    </select>
+  </div>
   <table class="table w-full table-zebra">
     <thead>
       <tr>
@@ -55,7 +80,6 @@
         <th>Device ID</th>
         <th>Level</th>
         <th>Position</th>
-        <th></th>
         <th></th>
       </tr>
     </thead>
@@ -67,13 +91,11 @@
           <td>{sensor.level}</td>
           <td>{sensor.position?.x.toFixed(2)}, {sensor.position?.y.toFixed(2)}, {sensor.position?.z.toFixed(2)}</td>
           <td>
-            <button class="btn btn-error btn-xs" on:click={() => confirmDelete(sensor.id)}>Delete</button>
-          </td>
-          <td>
-            <a class="btn btn-xs" href="/sensors/{sensor.id}">Details</a>
-          </td>
-          <td>
-            <button class="btn btn-xs" on:click={() => navigateToSensor(sensor.position)}>Go to</button>
+            <div class="flex justify-end gap-3">
+              <button class="btn btn-error btn-xs" on:click={() => confirmDelete(sensor.id)}>Delete</button>
+              <a class="btn btn-xs" href="/sensors/{sensor.id}">Details</a>
+              <button class="btn btn-xs" on:click={() => navigateToSensor(sensor.position)}>Go to</button>
+            </div>
           </td>
         </tr>
       {/each}

--- a/src/routes/projects/[id]/sensorlist/+page.svelte
+++ b/src/routes/projects/[id]/sensorlist/+page.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { PageData } from "../$types";
+  import { goto } from '$app/navigation';
+  import type { PageData } from './$types';
   import type { ISensor } from '../../../../lib/common/interfaces/ISensor';
   import type { IProject } from '../../../../services/sitevisor-types';
   import HeaderProject from '$lib/components/HeaderProject.svelte';
 	import { SitevisorService } from '../../../../services/sitevisor-service';
+	import type { Vector3 } from 'three';
   export let data: PageData;
 
   let project: IProject = data.project;
@@ -35,6 +37,12 @@
       }
     }
   }
+
+  function navigateToSensor(pos: Vector3 | null) {
+    if (pos) {
+      goto(`/projects/${project.id.toString()}/viewer?posX=${pos.x}&posY=${pos.y}&posZ=${pos.z}`);
+    }
+  }
 </script>
 
 <HeaderProject projectid={project.id.toString()}/>
@@ -63,6 +71,9 @@
           </td>
           <td>
             <a class="btn btn-xs" href="/sensors/{sensor.id}">Details</a>
+          </td>
+          <td>
+            <button class="btn btn-xs" on:click={() => navigateToSensor(sensor.position)}>Go to</button>
           </td>
         </tr>
       {/each}

--- a/src/routes/projects/[id]/sensorlist/+page.svelte
+++ b/src/routes/projects/[id]/sensorlist/+page.svelte
@@ -48,6 +48,7 @@
         <th>Level</th>
         <th>Position</th>
         <th></th>
+        <th></th>
       </tr>
     </thead>
     <tbody>
@@ -59,6 +60,9 @@
           <td>{sensor.position?.x.toFixed(2)}, {sensor.position?.y.toFixed(2)}, {sensor.position?.z.toFixed(2)}</td>
           <td>
             <button class="btn btn-error btn-xs" on:click={() => confirmDelete(sensor.id)}>Delete</button>
+          </td>
+          <td>
+            <a class="btn btn-xs" href="/sensors/{sensor.id}">Details</a>
           </td>
         </tr>
       {/each}

--- a/src/routes/projects/[id]/sensorlist/+page.ts
+++ b/src/routes/projects/[id]/sensorlist/+page.ts
@@ -1,0 +1,11 @@
+import { SitevisorService } from '../../../../services/sitevisor-service';
+
+export const ssr = false;
+
+export const load = async ({ params }) => {
+	SitevisorService.checkPageRefresh();
+	const project = await SitevisorService.getProjectById(encodeURI(params.id));
+	return {
+	  project: project,
+	};
+};

--- a/src/routes/projects/[id]/sensorlist/+page.ts
+++ b/src/routes/projects/[id]/sensorlist/+page.ts
@@ -1,10 +1,12 @@
+import type { Load } from '@sveltejs/kit';
 import { SitevisorService } from '../../../../services/sitevisor-service';
 
 export const ssr = false;
 
-export const load = async ({ params }) => {
+export const load: Load = async ({ params }) => {
 	SitevisorService.checkPageRefresh();
-	const project = await SitevisorService.getProjectById(encodeURI(params.id));
+	const projectId = params.id ?? ''; 
+	const project = await SitevisorService.getProjectById(encodeURI(projectId));
 	return {
 	  project: project,
 	};

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -5,7 +5,7 @@
 	import Header from '$lib/components/Header.svelte';
     import AddSensorDialog from '$lib/components/AddSensorDialog.svelte';
     import AddRoomDialog from '$lib/components/AddRoomDialog.svelte';
-    import type { PageData } from "../$types";
+    import type { PageData } from "./$types";
     import type { IProject } from "../../../../services/sitevisor-types";
 	import type { Sensor } from '$lib/assets/Sensor';
 	import { selectedSensorStore } from '../../../../stores';
@@ -14,6 +14,9 @@
 	export let data: PageData;
 
     const project: IProject = data.project;
+    const posX: number | null = Number(data.posX);
+    const posY: number | null = Number(data.posY);
+    const posZ: number | null = Number(data.posZ);
 
     let el: HTMLCanvasElement;
     let viewer: Viewer;
@@ -123,6 +126,8 @@
         });
 
         initializeWebSockets();
+
+        viewer.setCameraAt(posX, posY, posZ);
     });
 
     function updateSensorData(device_id: string, newData: any) {

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -215,7 +215,8 @@
 <AddSensorDialog
     bind:isDialogOpen={addSensorDialogVisible}
     bind:viewer={viewer}
-    />
+    projectId={project.id}
+/>
 
 <AddRoomDialog 
     bind:isDialogOpen={addRoomDialogVisible}

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -10,6 +10,7 @@
 	import type { Sensor } from '$lib/assets/Sensor';
 	import { selectedSensorStore } from '../../../../stores';
 	import SensorDetails from '$lib/components/SensorDetails.svelte';
+	import HeaderProject from '$lib/components/HeaderProject.svelte';
 	export let data: PageData;
 
     const project: IProject = data.project;
@@ -158,7 +159,7 @@
 </svelte:head>
 
 <div class="flex flex-col h-screen">
-    <Header />
+    <HeaderProject projectid={project.id.toString()}/>
     {#if selectedSensor}
         <SensorDetails on:removeSensor={e => viewer.removeSensorFromScene(e.detail.device_id)} selectedSensor={selectedSensor}/>
     {/if}

--- a/src/routes/projects/[id]/viewer/+page.ts
+++ b/src/routes/projects/[id]/viewer/+page.ts
@@ -1,11 +1,19 @@
 import { SitevisorService } from '../../../../services/sitevisor-service';
+import type { Load } from '@sveltejs/kit';
 
 export const ssr = false;
 
-export const load = async ({ params }) => {
+export const load: Load = async ({ params, url }) => {
 	SitevisorService.checkPageRefresh();
-	const project = await SitevisorService.getProjectById(encodeURI(params.id));
+	const projectId = params.id ?? ''; 
+	const project = await SitevisorService.getProjectById(encodeURI(projectId));
+	const posX = url.searchParams.get('posX');
+	const posY = url.searchParams.get('posY');
+	const posZ = url.searchParams.get('posZ');
 	return {
 	  project: project,
+	  posX: posX,
+	  posY: posY,
+	  posZ: posZ,
 	};
   };

--- a/src/routes/sensors/[id]/+page.svelte
+++ b/src/routes/sensors/[id]/+page.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import HeaderProject from "$lib/components/HeaderProject.svelte";
+    import type { PageData } from "./$types";
+    import { goto } from "$app/navigation";
+	import { SitevisorService } from "../../../services/sitevisor-service";
+    import type { ISensor } from "$lib/common/interfaces/ISensor";
+	export let data: PageData;
+
+    let sensor: ISensor = data.sensor;
+    let updatedName = sensor.name;
+    let updatedDeviceId = sensor.device_id;
+
+    async function deleteSensor() {
+        try {
+            await SitevisorService.deleteSensor(sensor.id.toString());
+            goto("/projects");
+        } catch (error) {
+            console.log("Error trying to delete Sensor: " + sensor.id);
+        }
+    }
+
+    // Function to handle form submission
+    async function updateSensor() {
+        const updatedSensor = {
+            ...sensor,
+            name: updatedName,
+            device_id: updatedDeviceId,
+        };
+
+        try {
+            await SitevisorService.updateSensor(sensor.id.toString(), updatedSensor);
+            sensor = updatedSensor;
+            console.log("Sensor updated successfully");
+        } catch (error) {
+            console.error("Error updating Sensor:", error);
+        }
+    }
+
+</script>
+
+<HeaderProject projectid={"1"}/>
+
+<div class="container mx-auto p-5">
+    <div class="card bg-base-100 shadow-xl">
+        <div class="card-body">
+            <h2 class="card-title">{sensor.name}</h2>
+            <p>Device ID: {sensor.device_id}</p>
+            <p>Level: {sensor.level}</p>
+            <div class="card-actions justify-end">
+                <button class="btn btn-error" on:click={deleteSensor}>Delete</button>
+            </div>
+        </div>
+    </div>
+    <div class="card bg-base-100 shadow-xl mt-4 w-1/2">
+        <div class="card-body">
+            <form on:submit|preventDefault={updateSensor} class="form">
+                <div class="form-control">
+                    <label class="label" for="sensorName">Sensor Name</label>
+                    <input class="input input-bordered" type="text" id="sensorName" bind:value={updatedName}>
+                </div>
+                <div class="form-control">
+                    <label class="label" for="sensorName">Device ID</label>
+                    <input class="input input-bordered" type="text" id="deviceId" bind:value={updatedDeviceId}>
+                </div>
+                <div class="card-actions justify-begin mt-4">
+                    <button type="submit" class="btn btn-primary">Update Sensor</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/src/routes/sensors/[id]/+page.svelte
+++ b/src/routes/sensors/[id]/+page.svelte
@@ -46,6 +46,7 @@
             <h2 class="card-title">{sensor.name}</h2>
             <p>Device ID: {sensor.device_id}</p>
             <p>Level: {sensor.level}</p>
+            <p>Type: {sensor.type}</p>
             <div class="card-actions justify-end">
                 <button class="btn btn-error" on:click={deleteSensor}>Delete</button>
             </div>

--- a/src/routes/sensors/[id]/+page.svelte
+++ b/src/routes/sensors/[id]/+page.svelte
@@ -46,7 +46,7 @@
             <h2 class="card-title">{sensor.name}</h2>
             <p>Device ID: {sensor.device_id}</p>
             <p>Level: {sensor.level}</p>
-            <p>Type: {sensor.type}</p>
+            <p>Type: {sensor.type.id}</p>
             <div class="card-actions justify-end">
                 <button class="btn btn-error" on:click={deleteSensor}>Delete</button>
             </div>

--- a/src/routes/sensors/[id]/+page.svelte
+++ b/src/routes/sensors/[id]/+page.svelte
@@ -21,16 +21,15 @@
 
     // Function to handle form submission
     async function updateSensor() {
-        const updatedSensor = {
-            ...sensor,
+        const updatedSensor: Partial<ISensor> = {
             name: updatedName,
             device_id: updatedDeviceId,
         };
 
         try {
-            await SitevisorService.updateSensor(sensor.id.toString(), updatedSensor);
-            sensor = updatedSensor;
-            console.log("Sensor updated successfully");
+        await SitevisorService.updateSensor(sensor.id.toString(), updatedSensor);
+        sensor = { ...sensor, ...updatedSensor };
+        console.log("Sensor updated successfully");
         } catch (error) {
             console.error("Error updating Sensor:", error);
         }

--- a/src/routes/sensors/[id]/+page.ts
+++ b/src/routes/sensors/[id]/+page.ts
@@ -1,9 +1,11 @@
+import type { Load } from "@sveltejs/kit";
 import { SitevisorService } from "../../../services/sitevisor-service";
 export const ssr = false;
 
-export const load = async ({ params }) => {
+export const load: Load = async ({ params }) => {
   SitevisorService.checkPageRefresh();
-  const sensor = await SitevisorService.getSensor(encodeURI(params.id));
+  const sensorId = params.id ?? ''; 
+  const sensor = await SitevisorService.getSensor(encodeURI(sensorId));
   return {
     sensor: sensor,
   };

--- a/src/routes/sensors/[id]/+page.ts
+++ b/src/routes/sensors/[id]/+page.ts
@@ -1,0 +1,10 @@
+import { SitevisorService } from "../../../services/sitevisor-service";
+export const ssr = false;
+
+export const load = async ({ params }) => {
+  SitevisorService.checkPageRefresh();
+  const sensor = await SitevisorService.getSensor(encodeURI(params.id));
+  return {
+    sensor: sensor,
+  };
+};

--- a/src/services/sitevisor-service.ts
+++ b/src/services/sitevisor-service.ts
@@ -66,11 +66,17 @@ export const SitevisorService = {
 		}
 	},
 
-	async getSensors(projectId: string): Promise<ISensor[]> {
+	async getSensors(projectId: string, sensorType?: string): Promise<ISensor[]> {
+		let url = `${this.baseUrl}/api/sensors/?project_id=${projectId}`;
+		if (sensorType) {
+			url += `&type=${sensorType}`;
+		}
+	
 		try {
-			const response = await axios.get(this.baseUrl + `/api/sensors/?project_id=${projectId}`);
+			const response = await axios.get(url);
 			return response.data;
 		} catch (error) {
+			console.error("Error fetching sensors", error);
 			return [];
 		}
 	},

--- a/src/services/sitevisor-service.ts
+++ b/src/services/sitevisor-service.ts
@@ -90,7 +90,7 @@ export const SitevisorService = {
 	async updateSensor(id: string, updatedSensorData: Partial<ISensor>): Promise<void> {
 		try {
 			const url = `${this.baseUrl}/api/sensors/${id}/`;
-			await axios.put(url, updatedSensorData);
+			await axios.patch(url, updatedSensorData);
 	
 			console.log("Sensor updated successfully");
 		} catch (error) {

--- a/src/services/sitevisor-service.ts
+++ b/src/services/sitevisor-service.ts
@@ -182,9 +182,12 @@ export const SitevisorService = {
 		}
 	},
 
-	async createProject(project: IProject) {
+	async createProject(project: IProject): Promise<IProject | undefined> {
 		try {
-			await axios.post(`${this.baseUrl}/api/projects/`, project);
+			const response = await axios.post(`${this.baseUrl}/api/projects/`, project);
+			if (response.data) {
+				return response.data as Promise<IProject>;
+			}
 		} catch (error) {
 			console.error("Error creating a Project", error);
 		}

--- a/src/services/sitevisor-service.ts
+++ b/src/services/sitevisor-service.ts
@@ -45,6 +45,27 @@ export const SitevisorService = {
 		}
 	  },
 
+	async getSensor(id: string): Promise<ISensor> {
+		try {
+			const response = await axios.get(this.baseUrl + `/api/sensors/${id}`);
+			return response.data;
+		} catch (error) {
+			console.log(error);
+			throw error;
+		}
+	},
+
+	async updateSensor(id: string, updatedSensorData: Partial<ISensor>): Promise<void> {
+		try {
+			const url = `${this.baseUrl}/api/sensors/${id}/`;
+			await axios.put(url, updatedSensorData);
+	
+			console.log("Sensor updated successfully");
+		} catch (error) {
+			console.error(`Error updating Sensor with id: ${id}`, error);
+		}
+	},
+
 	async getSensors(projectId: string): Promise<ISensor[]> {
 		try {
 			const response = await axios.get(this.baseUrl + `/api/sensors/?project_id=${projectId}`);

--- a/src/services/sitevisor-service.ts
+++ b/src/services/sitevisor-service.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import type { ISensor } from "../lib/common/interfaces/ISensor";
 import type { IRoom } from "../lib/common/interfaces/IRoom";
 import type { IProject } from "../services/sitevisor-types";
+import type { ISensorType } from "../services/sitevisor-types";
 import { loggedInUser } from "../stores";
 import { browser } from '$app/environment';
 
@@ -15,6 +16,38 @@ export const SitevisorService = {
 			return response.data;
 		} catch (error) {
 			return [];
+		}
+	},
+
+	async getSensorTypes(projectId: string): Promise<ISensorType[]> {
+		try {
+			const response = await axios.get(this.baseUrl + `/api/sensortypes/?project_id=${projectId}`);
+			return response.data;
+		} catch (error) {
+			return [];
+		}
+	},
+
+	async addSensorType(sensorTypeData: ISensorType): Promise<ISensorType | undefined> {
+		try {
+			const url = `${this.baseUrl}/api/sensortypes/`;
+			const response = await axios.post(url, sensorTypeData);
+	
+			console.log("Sensor Type created successfully");
+			if (response.data) {
+				return response.data as Promise<ISensorType>;
+			}
+		} catch (error) {
+			console.error(`Error creating SensorType: ${sensorTypeData.name}`, error);
+		}
+	},
+
+	async deleteSensorType(id: string): Promise<void> {
+		try {
+			await axios.delete(`${this.baseUrl}/api/sensortypes/${id}`);
+		} catch (error) {
+			console.error(`Error deleting SensorType with id ${id}`, error);
+			return;
 		}
 	},
 
@@ -66,10 +99,10 @@ export const SitevisorService = {
 		}
 	},
 
-	async getSensors(projectId: string, sensorType?: string): Promise<ISensor[]> {
+	async getSensors(projectId: string, sensorTypeId?: string): Promise<ISensor[]> {
 		let url = `${this.baseUrl}/api/sensors/?project_id=${projectId}`;
-		if (sensorType) {
-			url += `&type=${sensorType}`;
+		if (sensorTypeId) {
+			url += `&type=${sensorTypeId}`;
 		}
 	
 		try {

--- a/src/services/sitevisor-service.ts
+++ b/src/services/sitevisor-service.ts
@@ -1,8 +1,7 @@
 import axios from "axios";
-import type { ISensor } from "../lib/common/interfaces/ISensor";
+import type { ISensor, ISensorType } from "../lib/common/interfaces/ISensor";
 import type { IRoom } from "../lib/common/interfaces/IRoom";
 import type { IProject } from "../services/sitevisor-types";
-import type { ISensorType } from "../services/sitevisor-types";
 import { loggedInUser } from "../stores";
 import { browser } from '$app/environment';
 
@@ -120,7 +119,7 @@ export const SitevisorService = {
                 name: sensor.name,
 				device_id: sensor.device_id,
                 level: sensor.level,
-				type: sensor.type,
+				type_id: sensor.type.id,
                 position: { x: sensor.position?.x, y: sensor.position?.y, z: sensor.position?.z },
 				project: projectId
             };

--- a/src/services/sitevisor-service.ts
+++ b/src/services/sitevisor-service.ts
@@ -81,6 +81,7 @@ export const SitevisorService = {
                 name: sensor.name,
 				device_id: sensor.device_id,
                 level: sensor.level,
+				type: sensor.type,
                 position: { x: sensor.position?.x, y: sensor.position?.y, z: sensor.position?.z },
 				project: projectId
             };

--- a/src/services/sitevisor-types.ts
+++ b/src/services/sitevisor-types.ts
@@ -18,3 +18,9 @@ export interface IProject {
     rooms: IRoom[];
     sensors: ISensor[];
 }
+
+export interface ISensorType {
+    id: number;
+    name: string;
+    project: number;
+}

--- a/src/services/sitevisor-types.ts
+++ b/src/services/sitevisor-types.ts
@@ -18,9 +18,3 @@ export interface IProject {
     rooms: IRoom[];
     sensors: ISensor[];
 }
-
-export interface ISensorType {
-    id: number;
-    name: string;
-    project: number;
-}


### PR DESCRIPTION
This PR adds Sensor list page and Sensor details page.
The user is able to see all the sensors in the project in a single table and then navigate to the sensor details page, delete the sensor or navigate to the sensor position in the digital twin.

Also SensorType property was implemented. Users can add these types in the Project management page. Then the type can be selected when creating a new sensor.

Issues encountered:
- Setting the camera at sensor position wouldn't work at first when using `camera.lookAt`. Solution was to change `controls.target` on `OrbitControls`.

Further improvement could be colouring Sensors by type etc #60

Closes #33
Closes #34 