### PR TITLE
Sensor Data Heatmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can preview the production build with `npm run preview`.
 - [Typescript Classes](https://www.typescriptlang.org/docs/handbook/2/classes.html)
 - [Refactoring Guru - Design Patterns - Factory Method](https://refactoring.guru/design-patterns/factory-method)
 - [Svelte-awesome-color-picker](https://svelte-awesome-color-picker.vercel.app/)
+- [MDN Web Docs - Drawing shapes with canvas](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes)
 
 ## Documentation
 - [MkDocs - static site generator for project documentation](https://www.mkdocs.org/)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You can preview the production build with `npm run preview`.
 - [Refactoring Guru - Design Patterns - Factory Method](https://refactoring.guru/design-patterns/factory-method)
 - [Svelte-awesome-color-picker](https://svelte-awesome-color-picker.vercel.app/)
 - [MDN Web Docs - Drawing shapes with canvas](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes)
+- [HSL Gradient Canvas](https://codepen.io/acoreyj/pen/emLPwe)
 
 ## Documentation
 - [MkDocs - static site generator for project documentation](https://www.mkdocs.org/)

--- a/src/lib/assets/Heatmap.ts
+++ b/src/lib/assets/Heatmap.ts
@@ -45,11 +45,14 @@ export class Heatmap {
   }
 
   updateHeatmap(values: Array<[Vector3, number]>) {
-  // Takes in an array of value, position pairs to update the heatmap
-  const width = this.canvas.width;
-  const height = this.canvas.height;
+    // Takes in an array of value, position pairs to update the heatmap
+    // Creates a simple heatmap by drawing a rectangle at each data point, without any interpolation
 
-  if (this.ctx) {
+    if (!this.ctx) return; // Exit early
+
+    const width = this.canvas.width;
+    const height = this.canvas.height;
+
     // Clear previous drawing
     this.ctx.clearRect(0, 0, width, height);
     
@@ -69,7 +72,61 @@ export class Heatmap {
 
     this.texture.needsUpdate = true;
   }
-}
+
+  updateHeatmapAdvanced(sensors: Array<[Vector3, number]>) {
+    // This is a more advanced heatmap generation algorithm.
+    // It divides the canvas into a grid and colours the cells
+    // Normalised (0 to 1) Value of the cell is interpolated based on the value of all data points
+    // Each data point affects the cell value inversely proportional to the square of the distance
+
+    if (!this.ctx) return;
+  
+    const cellSize = 2;
+    const numCellsX = Math.ceil(this.canvas.width / cellSize);
+    const numCellsY = Math.ceil(this.canvas.height / cellSize);
+  
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+  
+    for (let i = 0; i < numCellsX; i++) {
+      for (let j = 0; j < numCellsY; j++) {
+        const x = i * cellSize + cellSize / 2;
+        const y = j * cellSize + cellSize / 2;
+  
+        const value = this.calculateGridValue(x - this.canvas.width / 2, y - this.canvas.height / 2, sensors);
+        const color = this.mapValueToColour(value, this.minValue, this.maxValue, this.minHue, this.maxHue);
+  
+        this.ctx.fillStyle = color;
+        this.ctx.fillRect(i * cellSize, j * cellSize, cellSize, cellSize);
+      }
+    }
+  
+    this.texture.needsUpdate = true;
+  }
+
+  private calculateGridValue(x: number, y: number, sensors: Array<[Vector3, number]>): number {
+    // Calculate cell value using inverse square distance weights
+    let totalValue = 0;
+    let totalWeight = 0;
+  
+    for (const [position, sensorValue] of sensors) {
+      const dx = x - position.x;
+      const dy = y - position.z;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+  
+      if (distance > 0) {
+        const weight = 1 / (distance*distance);
+        totalValue += sensorValue * weight;
+        totalWeight += weight;
+      }
+    }
+  
+    if (totalWeight > 0) {
+      return totalValue / totalWeight;
+    } else {
+      return 0; // Default value if no sensors are influencing the cell
+    }
+  }
+  
 
   mapValueToColour(value: number, minValue: number, maxValue: number, minHue: number, maxHue: number): string {
     // Maps the reading value to colour on a gradient

--- a/src/lib/assets/Heatmap.ts
+++ b/src/lib/assets/Heatmap.ts
@@ -36,6 +36,7 @@ export class Heatmap {
     this.planeGeometry.translate(0,0.01,0)
     this.planeMaterial = new MeshBasicMaterial({ map: this.texture, transparent: true, opacity: 0.9, alphaHash: true });
     this.plane = new Mesh(this.planeGeometry, this.planeMaterial);
+    this.plane.visible = false; // Hidden by default
     this.scene.add(this.plane);
 
     // Resolution of the heatmap
@@ -99,5 +100,9 @@ export class Heatmap {
       this.plane.position.setY(this.plane.position.y + roomHeight);
       this.geometryMode = "3D";
     }
+  }
+
+  public setVisibility(visibility: boolean) {
+    this.plane.visible = visibility;
   }
 }

--- a/src/lib/assets/Heatmap.ts
+++ b/src/lib/assets/Heatmap.ts
@@ -1,0 +1,69 @@
+import {
+  CanvasTexture,
+  PlaneGeometry,
+  MeshBasicMaterial,
+  Mesh,
+  Scene
+} from 'three';
+import { ReferencePlane } from './ReferencePlane';
+import type { Sensor } from './Sensor';
+
+export class Heatmap {
+  private canvas: HTMLCanvasElement;
+  private ctx: CanvasRenderingContext2D | null;
+  private texture: CanvasTexture;
+  public scene: Scene;
+  private referencePlane: ReferencePlane;
+  private planeGeometry: PlaneGeometry;
+  private planeMaterial: MeshBasicMaterial;
+  private plane: Mesh;
+
+  constructor(scene: Scene, referencePlane: ReferencePlane) {
+    this.scene = scene;
+    this.canvas = document.createElement('canvas');
+    this.ctx = this.canvas.getContext('2d');
+    this.texture = new CanvasTexture(this.canvas);
+    this.referencePlane = referencePlane;
+    this.planeGeometry = new PlaneGeometry(referencePlane.size, referencePlane.size);
+    this.planeGeometry.rotateX( - Math.PI / 2 );
+    this.planeGeometry.translate(0,-0.05,0)
+    this.planeMaterial = new MeshBasicMaterial({ map: this.texture, transparent: true, opacity: 0.5 });
+    this.plane = new Mesh(this.planeGeometry, this.planeMaterial);
+    this.scene.add(this.plane);
+
+    // Resolution of the heatmap
+    this.canvas.width = this.referencePlane.size;
+    this.canvas.height = this.referencePlane.size;
+  }
+
+  updateHeatmap(sensors: Map<string, Sensor>) {
+    const width = this.canvas.width;
+    const height = this.canvas.height;
+
+    if (this.ctx) {
+        // Clear previous drawing
+        this.ctx.clearRect(0, 0, width, height);
+
+        // Example: Iterate over sensor data and draw
+        for (const [_, sensor] of sensors) {
+            const color = this.mapValueToColour(sensor.userData.data?.value);
+            this.ctx.fillStyle = color;
+            const rectSize = 3;
+            this.ctx.fillRect(sensor.position.x + width/2 - rectSize/2,
+                sensor.position.z + height/2 - rectSize/2,
+                rectSize,
+                rectSize
+              );
+        };
+
+        this.texture.needsUpdate = true;
+    }
+}
+
+  mapValueToColour(value: number) {
+    // Mapping sensor value to heatmap colour
+    const r = Math.min(255, value * 4);
+    const b = 255 - r;
+    return `rgb(${r},0,${b})`;
+  }
+}

--- a/src/lib/assets/Heatmap.ts
+++ b/src/lib/assets/Heatmap.ts
@@ -17,7 +17,8 @@ export class Heatmap {
   private referencePlane: ReferencePlane;
   private planeGeometry: PlaneGeometry;
   private planeMaterial: MeshBasicMaterial;
-  private plane: Mesh;
+  public plane: Mesh;
+  private geometryMode: string;
 
   public minValue: number;
   public maxValue: number;
@@ -32,7 +33,7 @@ export class Heatmap {
     this.referencePlane = referencePlane;
     this.planeGeometry = new PlaneGeometry(referencePlane.size, referencePlane.size);
     this.planeGeometry.rotateX( - Math.PI / 2 );
-    this.planeGeometry.translate(0,3.05,0)
+    this.planeGeometry.translate(0,0.01,0)
     this.planeMaterial = new MeshBasicMaterial({ map: this.texture, transparent: true, opacity: 0.9, alphaHash: true });
     this.plane = new Mesh(this.planeGeometry, this.planeMaterial);
     this.scene.add(this.plane);
@@ -88,5 +89,15 @@ export class Heatmap {
 
     // Convert HSL to RGB
     return heatColour.getStyle();
+  }
+
+  public setGeometryMode(geometryMode: string, roomHeight: number) {
+    if (geometryMode === "2D" && this.geometryMode != "2D") {
+      this.plane.position.setY(this.plane.position.y - roomHeight);
+      this.geometryMode = "2D";
+    } else if (geometryMode === "3D" && this.geometryMode != "3D") {
+      this.plane.position.setY(this.plane.position.y + roomHeight);
+      this.geometryMode = "3D";
+    }
   }
 }

--- a/src/lib/assets/Heatmap.ts
+++ b/src/lib/assets/Heatmap.ts
@@ -3,10 +3,11 @@ import {
   PlaneGeometry,
   MeshBasicMaterial,
   Mesh,
-  Scene
+  Color,
+  Scene,
+  Vector3
 } from 'three';
 import { ReferencePlane } from './ReferencePlane';
-import type { Sensor } from './Sensor';
 
 export class Heatmap {
   private canvas: HTMLCanvasElement;
@@ -18,6 +19,11 @@ export class Heatmap {
   private planeMaterial: MeshBasicMaterial;
   private plane: Mesh;
 
+  public minValue: number;
+  public maxValue: number;
+  public minHue: number;
+  public maxHue: number;
+
   constructor(scene: Scene, referencePlane: ReferencePlane) {
     this.scene = scene;
     this.canvas = document.createElement('canvas');
@@ -26,8 +32,8 @@ export class Heatmap {
     this.referencePlane = referencePlane;
     this.planeGeometry = new PlaneGeometry(referencePlane.size, referencePlane.size);
     this.planeGeometry.rotateX( - Math.PI / 2 );
-    this.planeGeometry.translate(0,-0.05,0)
-    this.planeMaterial = new MeshBasicMaterial({ map: this.texture, transparent: true, opacity: 0.5 });
+    this.planeGeometry.translate(0,3.05,0)
+    this.planeMaterial = new MeshBasicMaterial({ map: this.texture, transparent: true, opacity: 0.9, alphaHash: true });
     this.plane = new Mesh(this.planeGeometry, this.planeMaterial);
     this.scene.add(this.plane);
 
@@ -36,34 +42,51 @@ export class Heatmap {
     this.canvas.height = this.referencePlane.size;
   }
 
-  updateHeatmap(sensors: Map<string, Sensor>) {
-    const width = this.canvas.width;
-    const height = this.canvas.height;
+  updateHeatmap(values: Array<[Vector3, number]>) {
+  // Takes in an array of value, position pairs to update the heatmap
+  const width = this.canvas.width;
+  const height = this.canvas.height;
 
-    if (this.ctx) {
-        // Clear previous drawing
-        this.ctx.clearRect(0, 0, width, height);
+  if (this.ctx) {
+    // Clear previous drawing
+    this.ctx.clearRect(0, 0, width, height);
+    
+    for (const [position, value] of values) {
+      const color = this.mapValueToColour(value, this.minValue, this.maxValue, this.minHue, this.maxHue);
+      this.ctx.fillStyle = color.toString();
+      // The shape drawn cannot be a circle as the drop in performance is too big, rect used instead
+      //this.ctx.fill()
+      //this.ctx.arc(sensor.position.x + width/2, sensor.position.z + height/2, rectSize, 0, 2* Math.PI);
+      const rectSize = 5;
+      this.ctx.fillRect(position.x + width/2 - rectSize/2,
+        position.z + height/2 - rectSize/2,
+        rectSize,
+        rectSize
+      );
+    };
 
-        // Example: Iterate over sensor data and draw
-        for (const [_, sensor] of sensors) {
-            const color = this.mapValueToColour(sensor.userData.data?.value);
-            this.ctx.fillStyle = color;
-            const rectSize = 3;
-            this.ctx.fillRect(sensor.position.x + width/2 - rectSize/2,
-                sensor.position.z + height/2 - rectSize/2,
-                rectSize,
-                rectSize
-              );
-        };
-
-        this.texture.needsUpdate = true;
-    }
+    this.texture.needsUpdate = true;
+  }
 }
 
-  mapValueToColour(value: number) {
-    // Mapping sensor value to heatmap colour
-    const r = Math.min(255, value * 4);
-    const b = 255 - r;
-    return `rgb(${r},0,${b})`;
+  mapValueToColour(value: number, minValue: number, maxValue: number, minHue: number, maxHue: number): string {
+    // Maps the reading value to colour on a gradient
+    // Uses Three.js Color object for convenience
+    // https://threejs.org/docs/#api/en/math/Color.lerpColors
+
+    const valuesRange = maxValue - minValue;
+    let valueNormalised = value - minValue;
+    if (valueNormalised !== 0) {
+      valueNormalised = (value - minValue) / valuesRange;
+    }
+
+    const minColour = new Color(`hsl(${maxHue}, 100%, 50%)`); // Green
+    const maxColour = new Color(`hsl(${minHue}, 100%, 50%)`); // Red
+
+    const heatColour = new Color(`hsl(0, 0%, 0%)`); // Initialise colour
+    heatColour.lerpColors(minColour, maxColour, valueNormalised);
+
+    // Convert HSL to RGB
+    return heatColour.getStyle();
   }
 }

--- a/src/lib/assets/ReferencePlane.ts
+++ b/src/lib/assets/ReferencePlane.ts
@@ -6,11 +6,13 @@ import {
 import { Plane } from './BaseTypes/Plane';
 
 export class ReferencePlane extends Plane {
+  public size: number;
 
   constructor(size: number = 20) {
     const geometry = new PlaneGeometry( size, size );
     geometry.rotateX( - Math.PI / 2 );
     super(geometry, new MeshBasicMaterial( { visible: false } ));
+    this.size = size;
     const gridHelper = new GridHelper(size, size, 0x444444, 0x444444);
     this.add(gridHelper);
   }

--- a/src/lib/assets/Room.ts
+++ b/src/lib/assets/Room.ts
@@ -1,5 +1,6 @@
 import {
   BoxGeometry,
+  BoxHelper,
   MeshStandardMaterial,
   Vector3,
 } from 'three';
@@ -14,6 +15,7 @@ export class Room extends Volume {
   private flatHeight: number;
   private materialNormal: MeshStandardMaterial;
   private materialSelected: MeshStandardMaterial;
+  public boxHelper: BoxHelper;
   public isSelected: boolean;
 
   constructor(id: string, color: number, opacity: number, name: string, level: number, project: number, sensors: string[], point1: Vector3, point2: Vector3) {
@@ -82,12 +84,18 @@ export class Room extends Volume {
     }
   }
 
+  public setBoxHelperVisibility(boxHelperVisibility: boolean) {
+    this.boxHelper.visible = boxHelperVisibility;
+  }
+
   public setIsSelected(isSelected: boolean) {
     this.isSelected = isSelected;
     if (isSelected) {
       this.material = this.materialSelected;
+      this.setBoxHelperVisibility(isSelected);
     } else {
       this.material = this.materialNormal;
+      this.setBoxHelperVisibility(isSelected);
     }
   }
 

--- a/src/lib/assets/Room.ts
+++ b/src/lib/assets/Room.ts
@@ -37,7 +37,7 @@ export class Room extends Volume {
     this.sizeZ = sizeZ;
     this.height = height;
     this.geometryMode = "3D";
-    this.flatHeight = 0.01;
+    this.flatHeight = 0.005;
     this.materialNormal = material;
 
     this.materialSelected = new MeshStandardMaterial({

--- a/src/lib/components/GradientBar.svelte
+++ b/src/lib/components/GradientBar.svelte
@@ -1,33 +1,41 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
-    export let minHue = 120; // Green
-    export let maxHue = 0; // Red
-    export let minValue: number;
-    export let maxValue: number;
-  
-    let canvas: HTMLCanvasElement;
-    let ctx: CanvasRenderingContext2D | null;
-  
-    function updateGradient() {
-      if (!ctx) return;
-      const gradient: CanvasGradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
-      gradient.addColorStop(0, `hsl(${minHue}, 100%, 50%)`); // Min hue at the top
-      gradient.addColorStop(0.5, `hsl(${(maxHue - minHue) / 2}, 100%, 50%)`); // Mid hue
-      gradient.addColorStop(1, `hsl(${maxHue}, 100%, 50%)`); // Max hue at the bottom
-  
-      ctx.fillStyle = gradient;
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-    };
-  
-    onMount(() => {
-      ctx = canvas.getContext('2d');
-      updateGradient();
-    });
-  
-    $: minValue, maxValue, updateGradient();
-  </script>
+  import type { ISensorType } from '$lib/common/interfaces/ISensor';
+  import { onMount } from 'svelte';
+  export let minHue = 120; // Green
+  export let maxHue = 0; // Red
+  export let minValue: number;
+  export let maxValue: number;
+  export let sensorTypes: ISensorType[];
+  export let sensorTypeFilter: string;
+
+  let canvas: HTMLCanvasElement;
+  let ctx: CanvasRenderingContext2D | null;
+
+  function updateGradient() {
+    if (!ctx) return;
+    const gradient: CanvasGradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+    gradient.addColorStop(0, `hsl(${minHue}, 100%, 50%)`); // Min hue at the top
+    gradient.addColorStop(0.5, `hsl(${(maxHue - minHue) / 2}, 100%, 50%)`); // Mid hue
+    gradient.addColorStop(1, `hsl(${maxHue}, 100%, 50%)`); // Max hue at the bottom
+
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  };
+
+  onMount(() => {
+    ctx = canvas.getContext('2d');
+    updateGradient();
+  });
+
+  $: minValue, maxValue, updateGradient();
+</script>
   
   <div class="grid justify-items-center">
+    <select id="sensorTypeSelect" class="select select-sm" bind:value={sensorTypeFilter} required>
+      {#each sensorTypes as type}
+        <option value={type.name}>{type.name}</option>
+      {/each}
+      </select>
     <div>
       <input type="number" class="input input-bordered w-16 max-w-xs" bind:value={maxValue}>
     </div>

--- a/src/lib/components/GradientBar.svelte
+++ b/src/lib/components/GradientBar.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+    export let minHue = 120; // Green
+    export let maxHue = 0; // Red
+    export let minValue: number;
+    export let maxValue: number;
+  
+    let canvas: HTMLCanvasElement;
+    let ctx: CanvasRenderingContext2D | null;
+  
+    function updateGradient() {
+      if (!ctx) return;
+      const gradient: CanvasGradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+      gradient.addColorStop(0, `hsl(${minHue}, 100%, 50%)`); // Min hue at the top
+      gradient.addColorStop(0.5, `hsl(${(maxHue - minHue) / 2}, 100%, 50%)`); // Mid hue
+      gradient.addColorStop(1, `hsl(${maxHue}, 100%, 50%)`); // Max hue at the bottom
+  
+      ctx.fillStyle = gradient;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    };
+  
+    onMount(() => {
+      ctx = canvas.getContext('2d');
+      updateGradient();
+    });
+  
+    $: minValue, maxValue, updateGradient();
+  </script>
+  
+  <div class="grid justify-items-center">
+    <div>
+      <input type="number" class="input input-bordered w-16 max-w-xs" bind:value={maxValue}>
+    </div>
+    <div>
+      <canvas bind:this={canvas} width="30" height="200"></canvas>
+    </div>
+    <div>
+      <input type="number" class="input input-bordered w-16 max-w-xs" bind:value={minValue}>
+    </div>
+  </div>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
     export let onToggleRoomInsertion: any;
     export let onToggleSensorInsertion: any;
+
+    export let isHeatmapActive: boolean;
 </script>
 
 <div class="drawer-side">
     <label for="my-drawer-2" aria-label="close sidebar" class="drawer-overlay"></label> 
     <ul class="menu p-4 w-80 min-h-full bg-base-200 text-base-content">
     <!-- Sidebar content here -->
-    <li><button class="btn" on:click={onToggleRoomInsertion}>Add Room</button></li>
-    <li><button class="btn" on:click={onToggleSensorInsertion}>Add Sensor</button></li>
+    <li><button class="btn mb-2" on:click={onToggleRoomInsertion}>Add Room</button></li>
+    <li><button class="btn mb-2" on:click={onToggleSensorInsertion}>Add Sensor</button></li>
+    <li><button class="btn {isHeatmapActive ? 'btn-active' : 'mb-2'}" on:click={() => isHeatmapActive = !isHeatmapActive}>Toggle Heatmap</button></li>
     </ul>
 </div>

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -16,9 +16,11 @@ export function formatDate(dateString: string): string {
   return date.toLocaleTimeString('en-IE', options);
 }
 
-export function sensorMapToReadingPositionArray(sensorMap: Map<string, Sensor>): Array<[Vector3, number]> {
-  return Array.from(sensorMap.values()).map(sensor => [
-    sensor.position,
-    sensor.userData.data?.value
-  ]);
+export function sensorMapToReadingPositionArray(sensorMap: Map<string, Sensor>, sensorTypeName: string): Array<[Vector3, number]> {
+  return Array.from(sensorMap.values())
+    .filter(sensor => sensor.userData.type === sensorTypeName)
+    .map(sensor => [
+      sensor.position,
+      sensor.userData.data?.value
+    ]);
 }

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -1,3 +1,6 @@
+import type { Sensor } from "$lib/assets/Sensor";
+import type { Vector3 } from "three/src/Three.js";
+
 export function getRandomHexColor(): number {
   return Math.floor(Math.random() * 16777215);
 }
@@ -11,4 +14,11 @@ export function formatDate(dateString: string): string {
   };
 
   return date.toLocaleTimeString('en-IE', options);
+}
+
+export function sensorMapToReadingPositionArray(sensorMap: Map<string, Sensor>): Array<[Vector3, number]> {
+  return Array.from(sensorMap.values()).map(sensor => [
+    sensor.position,
+    sensor.userData.data?.value
+  ]);
 }

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -436,7 +436,6 @@ export class Viewer {
         console.log("N key pressed");
         // Key presses are active when a modal window is opened.
         // This may cause potential bugs when user is typing into an input field.
-        this.heatmap.updateHeatmap(sensorMapToReadingPositionArray(this.sensors));
       }
   }
 

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -428,6 +428,7 @@ export class Viewer {
     this.rooms.forEach((room) => {
       room.setGeometryMode(geometryMode);
     });
+    this.heatmap.setGeometryMode(geometryMode, 3.0);
   }
 
   private onKeyPress(event: KeyboardEvent) {

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -12,6 +12,7 @@ import {
   Object3D,
   type Intersection,
   type Object3DEventMap,
+  BoxHelper,
 } from 'three';
 import { CSS2DRenderer } from 'three/addons/renderers/CSS2DRenderer.js';
 import { Room } from './assets/Room';
@@ -28,7 +29,6 @@ import { get } from 'svelte/store';
 import type { ISensor } from './common/interfaces/ISensor';
 import type { IRoom } from './common/interfaces/IRoom';
 import { Heatmap } from './assets/Heatmap';
-import { sensorMapToReadingPositionArray } from './utils/helpers';
 
 export class Viewer {
   private projectId: string;
@@ -74,6 +74,8 @@ export class Viewer {
           new Vector3(room.point1.x, room.point1.y, room.point1.z),
           new Vector3(room.point2.x, room.point2.y, room.point2.z));
         this.scene.add(newRoom);
+        const boxHelper = newRoom.boxHelper = new BoxHelper(newRoom, 0xffff00 );
+        this.scene.add(boxHelper);
         this.rooms.set(newRoom.userData.id, newRoom);
       }
     });
@@ -194,6 +196,10 @@ export class Viewer {
       this.pointerHelper.setCreateMode(this.sensorInsertionMode);
     }
     return this.sensorInsertionMode;
+  }
+
+  public setHeatmapVisibility(visibility: boolean) {
+    this.heatmap.setVisibility(visibility);
   }
 
   private checkPointerIntersection() {
@@ -357,11 +363,11 @@ export class Viewer {
       }
 
       // Proceed with removing the room
+      this.scene.remove(room.boxHelper);
       this.scene.remove(room);
       if (room.geometry) room.geometry.dispose();  
       this.rooms.delete(id);
     }
-    console.log(this.sensors)
   }
 
   private updateTempRoomPreview() {

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -27,6 +27,7 @@ import { RoomPreview } from './assets/RoomPreview';
 import { get } from 'svelte/store';
 import type { ISensor } from './common/interfaces/ISensor';
 import type { IRoom } from './common/interfaces/IRoom';
+import { Heatmap } from './assets/Heatmap';
 
 export class Viewer {
   private projectId: string;
@@ -50,6 +51,7 @@ export class Viewer {
 
   public sensors: Map<string, Sensor> = new Map();
   public rooms: Map<string, Room> = new Map();
+  public heatmap: Heatmap;
 
   private tempRoomPreview: RoomPreview | null = null;
 
@@ -135,6 +137,7 @@ export class Viewer {
     this.pointerHelper = new PointerHelper();
     this.scene.add(this.pointerHelper);
     this.loadObjects();
+    this.heatmap = new Heatmap(this.scene, this.referencePlane);
   }
 
   public setCameraAt(x: number, y: number, z: number) {
@@ -430,6 +433,7 @@ export class Viewer {
         console.log("N key pressed");
         // Key presses are active when a modal window is opened.
         // This may cause potential bugs when user is typing into an input field.
+        this.heatmap.updateHeatmap(this.sensors);
       }
   }
 

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -135,8 +135,8 @@ export class Viewer {
     this.referencePlane = new ReferencePlane();
     this.scene.add(this.referencePlane);
 
-    const axesHelper = new AxesHelper(5);
-    this.scene.add(axesHelper);
+    //const axesHelper = new AxesHelper(5);
+    //this.scene.add(axesHelper);
     this.pointerHelper = new PointerHelper();
     this.scene.add(this.pointerHelper);
     this.loadObjects();

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -28,6 +28,7 @@ import { get } from 'svelte/store';
 import type { ISensor } from './common/interfaces/ISensor';
 import type { IRoom } from './common/interfaces/IRoom';
 import { Heatmap } from './assets/Heatmap';
+import { sensorMapToReadingPositionArray } from './utils/helpers';
 
 export class Viewer {
   private projectId: string;
@@ -138,6 +139,7 @@ export class Viewer {
     this.scene.add(this.pointerHelper);
     this.loadObjects();
     this.heatmap = new Heatmap(this.scene, this.referencePlane);
+    this.heatmap.minHue = 0; this.heatmap.maxHue = 120; this.heatmap.minValue = 15; this.heatmap.maxValue = 30;
   }
 
   public setCameraAt(x: number, y: number, z: number) {
@@ -433,7 +435,7 @@ export class Viewer {
         console.log("N key pressed");
         // Key presses are active when a modal window is opened.
         // This may cause potential bugs when user is typing into an input field.
-        this.heatmap.updateHeatmap(this.sensors);
+        this.heatmap.updateHeatmap(sensorMapToReadingPositionArray(this.sensors));
       }
   }
 

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -12,6 +12,7 @@
 	import SensorDetails from '$lib/components/SensorDetails.svelte';
     import RoomDetails from '$lib/components/RoomDetails.svelte';
 	import HeaderProject from '$lib/components/HeaderProject.svelte';
+    import { sensorMapToReadingPositionArray } from '$lib/utils/helpers';
 	export let data: PageData;
 
     const project: IProject = data.project;
@@ -91,7 +92,7 @@
                 const message = JSON.parse(event.data);
                 const sensorData = JSON.parse(message.value.value); // Double parse due to the structure
                 updateSensorData(sensorData.sensor_id, sensorData.data);
-                viewer.heatmap.updateHeatmap(viewer.sensors);
+                viewer.heatmap.updateHeatmap(sensorMapToReadingPositionArray(viewer.sensors));
             });
 
             socket.addEventListener('close', (event) => {

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -102,7 +102,7 @@
                 const message = JSON.parse(event.data);
                 const sensorData = JSON.parse(message.value.value); // Double parse due to the structure
                 updateSensorData(sensorData.sensor_id, sensorData.data);
-                viewer.heatmap.updateHeatmap(sensorMapToReadingPositionArray(viewer.sensors));
+                viewer.heatmap.updateHeatmapAdvanced(sensorMapToReadingPositionArray(viewer.sensors));
             });
 
             socket.addEventListener('close', (event) => {

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -11,6 +11,7 @@
 	import { selectedSensorStore, selectedRoomStore } from '../../../../stores';
 	import SensorDetails from '$lib/components/SensorDetails.svelte';
     import RoomDetails from '$lib/components/RoomDetails.svelte';
+    import GradientBar from '$lib/components/GradientBar.svelte'
 	import HeaderProject from '$lib/components/HeaderProject.svelte';
     import { sensorMapToReadingPositionArray } from '$lib/utils/helpers';
 	export let data: PageData;
@@ -32,13 +33,20 @@
     let selectedSensor: Sensor | null = null;
     let selectedRoom: Room | null = null;
     let geometryMode3D: boolean = true;
+
     let heatmapVisibility: boolean = false;
+    let minValue: number = 15;
+    let maxValue: number = 30;
 
     $: if (viewer) {
         viewer.setRoomsGeometryMode(geometryMode3D ? '3D' : '2D');
         viewer.heatmap.setVisibility(heatmapVisibility);
+        if (viewer.heatmap) {
+            viewer.heatmap.minValue = minValue;
+            viewer.heatmap.maxValue = maxValue;
+        }
     }
-    
+
     function getTopicNamesArray() {
         return project.kafka_topics ? project.kafka_topics.split(',') : [];
     }
@@ -201,6 +209,16 @@
                         </label>
                     </div>
                 </div>
+                {#if heatmapVisibility}
+                <div class="absolute top-2 left-2 flex flex-col items-end z-10">
+                    <GradientBar
+                        minHue={0}
+                        maxHue={120}
+                        bind:minValue={minValue}
+                        bind:maxValue={maxValue}
+                    />
+                </div>
+                {/if}
             </div> 
 
             <Sidebar

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -32,9 +32,11 @@
     let selectedSensor: Sensor | null = null;
     let selectedRoom: Room | null = null;
     let geometryMode3D: boolean = true;
+    let heatmapVisibility: boolean = false;
 
     $: if (viewer) {
         viewer.setRoomsGeometryMode(geometryMode3D ? '3D' : '2D');
+        viewer.heatmap.setVisibility(heatmapVisibility);
     }
     
     function getTopicNamesArray() {
@@ -204,6 +206,7 @@
             <Sidebar
                 onToggleRoomInsertion={toggleRoomInsertion}
                 onToggleSensorInsertion={toggleSensorInsertion}
+                bind:isHeatmapActive={heatmapVisibility}
             />
         </div>
     </div>

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -36,11 +36,11 @@
 
     let heatmapVisibility: boolean = false;
     let minValue: number = 15;
-    let maxValue: number = 30;
+    let maxValue: number = 25;
 
     $: if (viewer) {
         viewer.setRoomsGeometryMode(geometryMode3D ? '3D' : '2D');
-        viewer.heatmap.setVisibility(heatmapVisibility);
+        viewer.setHeatmapVisibility(heatmapVisibility);
         if (viewer.heatmap) {
             viewer.heatmap.minValue = minValue;
             viewer.heatmap.maxValue = maxValue;

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -91,6 +91,7 @@
                 const message = JSON.parse(event.data);
                 const sensorData = JSON.parse(message.value.value); // Double parse due to the structure
                 updateSensorData(sensorData.sensor_id, sensorData.data);
+                viewer.heatmap.updateHeatmap(viewer.sensors);
             });
 
             socket.addEventListener('close', (event) => {


### PR DESCRIPTION
This PR adds a heatmap visualisation of the sensor data.

- The heatmap can be toggled via a button in the sidebar menu.
- Gradient scale appears on the screen with min and max reading values to be set by the user. For example for temperature we might want something like 90 for max and 40 for min and temperature 15 for min and 25 for max. Would be nice to have it pre-set by sensor type but it has to be this way for now.
- User can select sensor type from a selector, which will filter sensors and use only the selected type to render the heatmap.
- Heatmap gradient is however fixed to green and red values.
- Room BoxHelper was added to make the selected room visibility a bit better.

The heatmap obstructs the rooms quite a bit, but the opacity cannot be turned down any lower, because the colours start to become very faint in high transparency.
Probably best to view in 2D mode for that reason, because it shows all sensors and also we can still select a room and see a 3D BoxHelper highlighting it on top of the heatmap.


In general, quite happy with the result:
![image](https://github.com/grzpiotrowski/sitevisor/assets/97438342/6c6ca81d-e76c-4d6b-8537-bdc06ea5bc44)


Closes #54 