### PR TITLE
Room pages and Sensor-Room relation

### DIFF
--- a/src/lib/assets/Room.ts
+++ b/src/lib/assets/Room.ts
@@ -51,7 +51,8 @@ export class Room extends Volume {
       id: id,
       name: name,
       level: level,
-      project: project
+      project: project,
+      sensors: [],
     };
 
     this.isSelected = false;

--- a/src/lib/assets/Room.ts
+++ b/src/lib/assets/Room.ts
@@ -16,7 +16,7 @@ export class Room extends Volume {
   private materialSelected: MeshStandardMaterial;
   public isSelected: boolean;
 
-  constructor(id: string, color: number, opacity: number, name: string, level: number, project: number, point1: Vector3, point2: Vector3) {
+  constructor(id: string, color: number, opacity: number, name: string, level: number, project: number, sensors: string[], point1: Vector3, point2: Vector3) {
 
     const sizeX = Math.abs(point2.x - point1.x);
     const sizeZ = Math.abs(point2.z - point1.z);
@@ -52,7 +52,7 @@ export class Room extends Volume {
       name: name,
       level: level,
       project: project,
-      sensors: [],
+      sensors: sensors,
     };
 
     this.isSelected = false;
@@ -104,5 +104,18 @@ export class Room extends Volume {
       }
     }
     return sensorsInRoom;
+  }
+
+  public removeSensorEntry(sensorId: string) {
+    let index: number = this.userData.sensors.indexOf(sensorId);
+    if (index !== -1) {
+      this.userData.sensors.splice(index, 1);
+    }
+  }
+
+  public addSensorEntry(sensorId: string) {
+    if (this.userData.sensors.indexOf(sensorId) === -1) {
+    this.userData.sensors.push(sensorId);
+    }
   }
 }

--- a/src/lib/assets/Room.ts
+++ b/src/lib/assets/Room.ts
@@ -92,6 +92,10 @@ export class Room extends Volume {
   }
 
   public checkSensorsWithin(sensors: Map<string, Sensor>): Map<string, Sensor> {
+    // Add a small height (skin width) for the detection purposes
+    // Sensor is exactly on the floor of the room so it could happen that its not detected inside due to float
+    const skinWidth: number = 0.01;
+
     const sensorsInRoom: Map<string, Sensor> = new Map();
     this.geometry.computeBoundingBox();
     // Bounding box has only min max values, needs to be shifted to objects location
@@ -99,7 +103,10 @@ export class Room extends Volume {
     const bbox = this.geometry.boundingBox?.clone()
     bbox?.translate(this.position);
     for (const [device_id, sensor] of sensors) {
-      if (bbox?.containsPoint(sensor.position)) {
+      
+      const sensorPosition = sensor.position.clone();
+      sensorPosition.setY(sensorPosition.y + skinWidth);
+      if (bbox?.containsPoint(sensorPosition)) {
         sensorsInRoom.set(device_id, sensor);
       }
     }

--- a/src/lib/assets/Room.ts
+++ b/src/lib/assets/Room.ts
@@ -4,6 +4,7 @@ import {
   Vector3,
 } from 'three';
 import { Volume } from './BaseTypes/Volume';
+import type { Sensor } from './Sensor';
 
 export class Room extends Volume {
   private sizeX: number;
@@ -87,5 +88,16 @@ export class Room extends Volume {
     } else {
       this.material = this.materialNormal;
     }
+  }
+
+  public checkSensorsWithin(sensors: Map<string, Sensor>): Map<string, Sensor> {
+    const sensorsInRoom: Map<string, Sensor> = new Map();
+    this.geometry.computeBoundingBox();
+    for (const [device_id, sensor] of sensors) {
+      if (this.geometry.boundingBox?.translate(this.position).containsPoint(sensor.position)) {
+        sensorsInRoom.set(device_id, sensor);
+      }
+    }
+    return sensorsInRoom;
   }
 }

--- a/src/lib/assets/Room.ts
+++ b/src/lib/assets/Room.ts
@@ -51,7 +51,7 @@ export class Room extends Volume {
       id: id,
       name: name,
       level: level,
-      project: project,
+      project: project
     };
 
     this.isSelected = false;
@@ -93,8 +93,12 @@ export class Room extends Volume {
   public checkSensorsWithin(sensors: Map<string, Sensor>): Map<string, Sensor> {
     const sensorsInRoom: Map<string, Sensor> = new Map();
     this.geometry.computeBoundingBox();
+    // Bounding box has only min max values, needs to be shifted to objects location
+    // Creating a copy of the bounding box so it is not shifted into far far away
+    const bbox = this.geometry.boundingBox?.clone()
+    bbox?.translate(this.position);
     for (const [device_id, sensor] of sensors) {
-      if (this.geometry.boundingBox?.translate(this.position).containsPoint(sensor.position)) {
+      if (bbox?.containsPoint(sensor.position)) {
         sensorsInRoom.set(device_id, sensor);
       }
     }

--- a/src/lib/assets/Sensor.ts
+++ b/src/lib/assets/Sensor.ts
@@ -13,7 +13,7 @@ export class Sensor extends Point3D {
   label: SensorLabel;
   isSelected: boolean;
 
-  constructor(id: string, name: string, device_id: string, level: number, type: string, project: number, position: Vector3) {
+  constructor(id: string, name: string, device_id: string, level: number, type: string, project: number, position: Vector3, room: string | null) {
     super(position);
 
     this.geometry = new BoxGeometry(0.5, 0.5, 0.5);
@@ -31,7 +31,7 @@ export class Sensor extends Point3D {
       level: level,
       type: type,
       project: project,
-      room: null,
+      room: room,
       data: null
     };
 
@@ -75,5 +75,9 @@ export class Sensor extends Point3D {
         return room;
       }
     }
+  }
+
+  public setRoomEntry(roomId: string | null) {
+    this.userData.room = roomId;
   }
 }

--- a/src/lib/assets/Sensor.ts
+++ b/src/lib/assets/Sensor.ts
@@ -5,6 +5,7 @@ import {
   } from 'three';
 import { Point3D } from './BaseTypes/Point3D';
 import { SensorLabel } from './SensorLabel';
+import type { Room } from './Room';
   
 export class Sensor extends Point3D {
   material: MeshStandardMaterial;
@@ -63,6 +64,15 @@ export class Sensor extends Point3D {
       this.label.element.style.visibility = 'visible';
     } else {
       this.label.element.style.visibility = 'hidden';
+    }
+  }
+
+  public checkIsInsideRoom(rooms: Map<string, Room>): Room | undefined {
+    for (const [room_id, room] of rooms) {
+      room.geometry.computeBoundingBox();
+      if (room.geometry.boundingBox?.translate(room.position).containsPoint(this.position)) {
+        return room;
+      }
     }
   }
 }

--- a/src/lib/assets/Sensor.ts
+++ b/src/lib/assets/Sensor.ts
@@ -69,9 +69,15 @@ export class Sensor extends Point3D {
   }
 
   public checkIsInsideRoom(rooms: Map<string, Room>): Room | undefined {
+    // Add a small height (skin width) for the detection purposes
+    // Sensor is exactly on the floor of the room so it could happen that its not detected inside due to float
+    const skinWidth: number = 0.01;
+    const sensorPosition = this.position.clone();
+    sensorPosition.setY(sensorPosition.y + skinWidth);
+
     for (const [room_id, room] of rooms) {
       room.geometry.computeBoundingBox();
-      if (room.geometry.boundingBox?.translate(room.position).containsPoint(this.position)) {
+      if (room.geometry.boundingBox?.translate(room.position).containsPoint(sensorPosition)) {
         return room;
       }
     }

--- a/src/lib/assets/Sensor.ts
+++ b/src/lib/assets/Sensor.ts
@@ -31,6 +31,7 @@ export class Sensor extends Point3D {
       level: level,
       type: type,
       project: project,
+      room: null,
       data: null
     };
 

--- a/src/lib/common/interfaces/IRoom.ts
+++ b/src/lib/common/interfaces/IRoom.ts
@@ -1,4 +1,5 @@
 import { Vector3 } from "three";
+import type { ISensor } from "./ISensor";
 
 /**
  * Interface representing the properties required to create a Room.
@@ -12,4 +13,5 @@ export interface IRoom {
   point1: Vector3 | null;
   point2: Vector3 | null;
   project: number;
+  sensors: ISensor[] | null;
 }

--- a/src/lib/common/interfaces/IRoom.ts
+++ b/src/lib/common/interfaces/IRoom.ts
@@ -13,5 +13,5 @@ export interface IRoom {
   point1: Vector3 | null;
   point2: Vector3 | null;
   project: number;
-  sensors: ISensor[] | null;
+  sensors: string[];
 }

--- a/src/lib/common/interfaces/ISensor.ts
+++ b/src/lib/common/interfaces/ISensor.ts
@@ -12,7 +12,7 @@ export interface ISensor {
   position: Vector3 | null;
   type: ISensorType;
   project: number;
-  room: IRoom | null;
+  room: string | null;
 }
 
 export interface ISensorType {

--- a/src/lib/common/interfaces/ISensor.ts
+++ b/src/lib/common/interfaces/ISensor.ts
@@ -1,4 +1,5 @@
 import { Vector3 } from "three";
+import type { IRoom } from "./IRoom";
 
 /**
  * Interface representing the properties required to create a Sensor.
@@ -11,6 +12,7 @@ export interface ISensor {
   position: Vector3 | null;
   type: ISensorType;
   project: number;
+  room: IRoom | null;
 }
 
 export interface ISensorType {

--- a/src/lib/components/AddIssueDialog.svelte
+++ b/src/lib/components/AddIssueDialog.svelte
@@ -39,7 +39,7 @@
     // Ideally ISensor and IRoom would have a parent interface
     async function fetchObjects(type: string) {
         if (type === 'sensor') {
-            objects = await SitevisorService.getSensors(projectId);
+            objects = await SitevisorService.getSensors({project_id: projectId});
         } else if (type === 'room') {
             objects = await SitevisorService.getRooms(projectId);
         }

--- a/src/lib/components/AddRoomDialog.svelte
+++ b/src/lib/components/AddRoomDialog.svelte
@@ -29,7 +29,7 @@
                 project: projectId,
                 point1: null,
                 point2: null,
-                sensors: null,
+                sensors: [],
             }
             ));
         isDialogOpen = false;

--- a/src/lib/components/AddRoomDialog.svelte
+++ b/src/lib/components/AddRoomDialog.svelte
@@ -18,7 +18,7 @@
     };
 
     function handleAddRoomSubmit() {
-        // Update details in store but temporarily set position to null
+        // Update details in store but temporarily set position and sensors to null
         newRoom.update(() => (
             { 
                 id: '',
@@ -28,7 +28,8 @@
                 opacity: 0.5,
                 project: projectId,
                 point1: null,
-                point2: null
+                point2: null,
+                sensors: null,
             }
             ));
         isDialogOpen = false;

--- a/src/lib/components/AddSensorDialog.svelte
+++ b/src/lib/components/AddSensorDialog.svelte
@@ -43,7 +43,7 @@
             return;
         }
 
-        // Update details in store but temporarily set position to null
+        // Update details in store but temporarily set position and room to null
         newSensor.update(() => (
             {   
                 id: '',
@@ -53,6 +53,7 @@
                 position: null,
                 type: selectedType,
                 project: projectId,
+                room: null,
             }
         ));
         isDialogOpen = false;

--- a/src/lib/components/HeaderProject.svelte
+++ b/src/lib/components/HeaderProject.svelte
@@ -10,6 +10,7 @@
       <ul class="menu menu-horizontal px-1">
         <li><a href="/projects">Projects</a></li>
         <li><a href="/projects/{projectid}/viewer">Digital Twin</a></li>
+        <li><a href="/projects/{projectid}/rooms">Rooms</a></li>
         <li><a href="/projects/{projectid}/sensors">Sensors</a></li>
         <li><a href="/projects/{projectid}/issues">Issues</a></li>
         <li><a href="/logout">Logout</a></li>

--- a/src/lib/components/IssuesTable.svelte
+++ b/src/lib/components/IssuesTable.svelte
@@ -36,8 +36,8 @@
       {/each}
     </select>
     {#if showTypeFilter}
-    <label class="label text-sm mr-3" for="sensorTypeSelect">Sensor Type: </label>
-    <select id="sensorTypeSelect" class="select select-sm" bind:value={objectTypeFilter}>
+    <label class="label text-sm mr-3" for="objectTypeSelect">Object Type: </label>
+    <select id="objectTypeSelect" class="select select-sm" bind:value={objectTypeFilter}>
       <option value="">All</option>
       {#each Array.from(objectTypes.values()) as objectType}
         <option value={objectType}>{objectType}</option>

--- a/src/lib/components/RoomDetails.svelte
+++ b/src/lib/components/RoomDetails.svelte
@@ -56,6 +56,7 @@
   <button class="absolute top-0 right-0 m-2" on:click={closeRoomDetails}>&times;</button>
   <h3 class="text-lg font-semibold">Room: {selectedRoom?.userData.name}</h3>
   <p>Level: {selectedRoom?.userData.level}</p>
+  <p>Sensors: {selectedRoom?.userData.sensors.length}</p>
   <a class="btn btn-sm" href="/projects/{selectedRoom?.userData.project}/rooms/{selectedRoom?.userData.id}">Details</a>
   <button class="btn btn-primary btn-sm" on:click={openAddIssueDialog}>Add Issue</button>
   <button class="btn btn-error btn-sm" on:click={() => showRoomDeleteModal = true}>Delete Room</button>

--- a/src/lib/components/RoomDetails.svelte
+++ b/src/lib/components/RoomDetails.svelte
@@ -56,6 +56,7 @@
   <button class="absolute top-0 right-0 m-2" on:click={closeRoomDetails}>&times;</button>
   <h3 class="text-lg font-semibold">Room: {selectedRoom?.userData.name}</h3>
   <p>Level: {selectedRoom?.userData.level}</p>
+  <a class="btn btn-sm" href="/projects/{selectedRoom?.userData.project}/rooms/{selectedRoom?.userData.id}">Details</a>
   <button class="btn btn-primary btn-sm" on:click={openAddIssueDialog}>Add Issue</button>
   <button class="btn btn-error btn-sm" on:click={() => showRoomDeleteModal = true}>Delete Room</button>
   {#if showRoomDeleteModal}

--- a/src/lib/components/SensorDetails.svelte
+++ b/src/lib/components/SensorDetails.svelte
@@ -138,6 +138,7 @@
   <canvas bind:this={chartCanvas}></canvas>
   <p>ID: {selectedSensor?.userData.device_id}</p>
   <p>Level: {selectedSensor?.userData.level}</p>
+  <p>Room: {selectedSensor?.userData.room}</p>
   <p>Type: {selectedSensor?.userData.type}</p>
   {#if selectedSensor?.userData.data}
     <p>Reading: {selectedSensor?.userData.data.value} {selectedSensor?.userData.data.unit}</p>

--- a/src/lib/components/SensorDetails.svelte
+++ b/src/lib/components/SensorDetails.svelte
@@ -7,8 +7,11 @@
   import { SitevisorService } from "../../services/sitevisor-service";
   import Chart from 'chart.js/auto';
 	import type { IIssue } from '../../services/sitevisor-types';
+	import type { Room } from '$lib/assets/Room';
 
   export let selectedSensor: Sensor | null;
+  export let rooms: Map<string, Room>;
+  
   let showSensorDeleteModal = false;
   let chart: Chart | null = null;
   let chartCanvas: HTMLCanvasElement;
@@ -138,7 +141,7 @@
   <canvas bind:this={chartCanvas}></canvas>
   <p>ID: {selectedSensor?.userData.device_id}</p>
   <p>Level: {selectedSensor?.userData.level}</p>
-  <p>Room: {selectedSensor?.userData.room}</p>
+  <p>Room: {rooms.get(selectedSensor?.userData.room)?.userData.name ?? 'Not assigned'}</p>
   <p>Type: {selectedSensor?.userData.type}</p>
   {#if selectedSensor?.userData.data}
     <p>Reading: {selectedSensor?.userData.data.value} {selectedSensor?.userData.data.unit}</p>

--- a/src/lib/components/SensorTable.svelte
+++ b/src/lib/components/SensorTable.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import type { ISensor, ISensorType } from '$lib/common/interfaces/ISensor';
+  import { SitevisorService } from '../../services/sitevisor-service';
+  import type { Vector3 } from 'three';
+
+  export let projectId: string;
+  export let sensors: ISensor[];
+  export let sensorTypes: ISensorType[];
+
+  let sensorTypeFilter: string = "";
+
+  let pendingDeleteSensorId: string | null = null;
+  let showSensorDeleteModal: boolean = false;
+
+  $: filteredSensors = sensors.map(sensor => ({
+    ...sensor
+  })).filter(sensor => {
+    return (sensorTypeFilter ? sensor.type.id.toString() === sensorTypeFilter : true);
+  });
+  
+  function confirmDelete(sensorId: string) {
+    pendingDeleteSensorId = sensorId;
+    showSensorDeleteModal = true;
+  }
+
+  async function deleteSensor() {
+    if (pendingDeleteSensorId) {
+      try {
+        await SitevisorService.deleteSensor(pendingDeleteSensorId);  
+        sensors = sensors.filter(s => s.id !== pendingDeleteSensorId);
+        showSensorDeleteModal = false;
+        pendingDeleteSensorId = null;
+      } catch (error) {
+        console.error("Error deleting sensor", error);
+      }
+    }
+  }
+
+  function navigateToSensor(pos: Vector3 | null) {
+    if (pos) {
+      goto(`/projects/${projectId}/viewer?posX=${pos.x}&posY=${pos.y}&posZ=${pos.z}`);
+    }
+  }
+</script>
+  
+<div class="mb-4 flex items-center">
+  <label class="label mr-3" for="sensorTypeSelect">Sensor Type: </label>
+  <select id="sensorTypeSelect" class="select select-sm" bind:value={sensorTypeFilter} required>
+  <option selected value="">All</option>
+  {#each sensorTypes as type}
+    <option value={type.id.toString()}>{type.name}</option>
+  {/each}
+  </select>
+</div>
+<table class="table w-full table-zebra">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Device ID</th>
+      <th>Type</th>
+      <th>Level</th>
+      <th>Position</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  {#each filteredSensors as sensor}
+    <tr>
+    <td>{sensor.name}</td>
+    <td>{sensor.device_id}</td>
+    <td>{sensor.type.name}</td>
+    <td>{sensor.level}</td>
+    <td>{sensor.position?.x.toFixed(2)}, {sensor.position?.y.toFixed(2)}, {sensor.position?.z.toFixed(2)}</td>
+    <td>
+      <div class="flex justify-end gap-3">
+        <button class="btn btn-error btn-xs" on:click={() => confirmDelete(sensor.id)}>Delete</button>
+        <a class="btn btn-xs" href="/projects/{projectId}/sensors/{sensor.id}">Details</a>
+        <button class="btn btn-xs" on:click={() => navigateToSensor(sensor.position)}>Go to</button>
+      </div>
+    </td>
+    </tr>
+  {/each}
+  </tbody>
+</table>
+{#if showSensorDeleteModal}
+  <div class="modal modal-open">
+    <div class="modal-box">
+      <h3 class="text-lg font-bold">Confirm Deletion</h3>
+      <p>Are you sure you want to delete this sensor?</p>
+      <div class="modal-action">
+        <button class="btn" on:click={() => showSensorDeleteModal = false}>Cancel</button>
+        <button class="btn btn-error" on:click={deleteSensor}>Delete</button>
+      </div>
+    </div>
+  </div>  
+{/if}
+    

--- a/src/lib/utils/ObjectFactory.ts
+++ b/src/lib/utils/ObjectFactory.ts
@@ -19,7 +19,7 @@ export class ObjectFactory {
 
   createRoom(options: IRoom): Room | undefined {
     if (options.point1 != null && options.point2 != null) {
-      const room = new Room(options.id, options.color, options.opacity, options.name, options.level, options.project, options.point1, options.point2);
+      const room = new Room(options.id, options.color, options.opacity, options.name, options.level, options.project, options.sensors, options.point1, options.point2);
       this.scene.add(room);
       this.viewer.rooms.set(room.userData.id, room);
       return room;
@@ -29,7 +29,14 @@ export class ObjectFactory {
 
   createSensor(options: ISensor): Sensor | undefined {
     if (options.position != null) {
-      const sensor = new Sensor(options.id, options.name, options.device_id, options.level, options.type.name, options.project, options.position);
+      const sensor = new Sensor(options.id,
+        options.name,
+        options.device_id,
+        options.level,
+        options.type.name,
+        options.project,
+        options.position,
+        options.room);
       this.scene.add(sensor);
       this.scene.add(sensor.label);
       this.viewer.sensors.set(sensor.userData.device_id, sensor);

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -67,7 +67,7 @@ export class Viewer {
     const rooms = await SitevisorService.getRooms(this.projectId);
     rooms.forEach((room) => {
       if (room.point1 != null && room.point2 != null) {
-        const newRoom = new Room(room.id, room.color, room.opacity, room.name, room.level, room.project,
+        const newRoom = new Room(room.id, room.color, room.opacity, room.name, room.level, room.project, room.sensors,
           new Vector3(room.point1.x, room.point1.y, room.point1.z),
           new Vector3(room.point2.x, room.point2.y, room.point2.z));
         this.scene.add(newRoom);
@@ -83,7 +83,8 @@ export class Viewer {
         sensor.level,
         sensor.type.name,
         sensor.project,
-        new Vector3(sensor.position?.x, sensor.position?.y, sensor.position?.z));
+        new Vector3(sensor.position?.x, sensor.position?.y, sensor.position?.z),
+        sensor.room);
       this.scene.add(newSensor);
       this.scene.add(newSensor.label)
       this.sensors.set(newSensor.userData.device_id, newSensor);
@@ -314,6 +315,11 @@ export class Viewer {
   public removeSensorFromScene(device_id: string): void {
     const sensor = this.sensors.get(device_id);
     if (sensor) {
+      // Update room related to the sensor
+      if (sensor.userData.room) {
+        this.rooms.get(sensor.userData.room)?.removeSensorEntry(sensor.userData.id);
+      }
+      // Proceed with removing the sensor
       this.scene.remove(sensor);
       this.scene.remove(sensor.label);
   
@@ -334,10 +340,23 @@ export class Viewer {
   public removeRoomFromScene(id: string): void {
     const room = this.rooms.get(id);
     if (room) {
+      // Remove Room entry from related Sensors
+      if (room.userData.sensors) {
+        // Iterating this way around due to device_id and id mismatch
+        // Could fix that. This is bad O(n) surely
+        for (const [device_id, sensor] of this.sensors) {
+          if (room.userData.sensors.indexOf(sensor.userData.id) !== -1) {
+            sensor.setRoomEntry(null);
+          }
+        }
+      }
+
+      // Proceed with removing the room
       this.scene.remove(room);
       if (room.geometry) room.geometry.dispose();  
       this.rooms.delete(id);
     }
+    console.log(this.sensors)
   }
 
   private updateTempRoomPreview() {
@@ -363,11 +382,10 @@ export class Viewer {
 
   private async updateRoomContent(room: Room) {
     const sensorsWithin = room.checkSensorsWithin(this.sensors);
-    console.log(sensorsWithin)
     for (let [sensorId, sensor] of sensorsWithin) {  
       // Update properties locally
-      sensor.userData.room = room.userData.id;
-      room.userData.sensors.push(sensor.userData.id);
+      this.sensors.get(sensorId)?.setRoomEntry(room.userData.id);
+      this.rooms.get(room.userData.id)?.addSensorEntry(sensor.userData.id);
   
       // Backend update
       const updatedSensorData: Partial<ISensor> = {
@@ -388,7 +406,8 @@ export class Viewer {
     const room = sensor.checkIsInsideRoom(this.rooms);
     if (room) {
       // Update properties locally
-      sensor.userData.room = room.userData.id;
+      this.sensors.get(sensor.userData.device_id)?.setRoomEntry(room.userData.id);
+      this.rooms.get(room.userData.id)?.addSensorEntry(sensor.userData.id);
       // Backend update
       SitevisorService.updateSensor(sensor.userData.id, { room: room.userData.id });
     }

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -74,7 +74,7 @@ export class Viewer {
         this.rooms.set(newRoom.userData.id, newRoom);
       }
     });
-    const sensors = await SitevisorService.getSensors(this.projectId);
+    const sensors = await SitevisorService.getSensors( {project_id: this.projectId} );
     sensors.forEach((sensor) => {
       const newSensor = new Sensor(
         sensor.id,

--- a/src/routes/projects/[id]/rooms/+page.svelte
+++ b/src/routes/projects/[id]/rooms/+page.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import type { PageData } from './$types';
+  import type { IRoom} from '../../../../lib/common/interfaces/IRoom';
+  import type { IProject } from '../../../../services/sitevisor-types';
+  import HeaderProject from '$lib/components/HeaderProject.svelte';
+	import { SitevisorService } from '../../../../services/sitevisor-service';
+	import type { Vector3 } from 'three';
+  export let data: PageData;
+
+  let project: IProject = data.project;
+  let rooms: IRoom[] = [];
+
+  let pendingDeleteRoomId: string | null = null;
+  let showRoomDeleteModal: boolean = false;
+
+  onMount(() => {
+    fetchRooms();
+  });
+
+  async function fetchRooms() {
+    rooms = await SitevisorService.getRooms(project.id.toString());
+  }
+
+  function confirmDelete(roomId: string) {
+    pendingDeleteRoomId = roomId;
+    showRoomDeleteModal = true;
+  }
+
+  async function deleteRoom() {
+    if (pendingDeleteRoomId) {
+      try {
+        await SitevisorService.deleteRoom(pendingDeleteRoomId);  
+        rooms = rooms.filter(r => r.id !== pendingDeleteRoomId);
+        showRoomDeleteModal = false;
+        pendingDeleteRoomId = null;
+      } catch (error) {
+        console.error("Error deleting room", error);
+      }
+    }
+  }
+
+  function navigateToSensor(pos: Vector3 | null) {
+    if (pos) {
+      goto(`/projects/${project.id.toString()}/viewer?posX=${pos.x}&posY=${pos.y}&posZ=${pos.z}`);
+    }
+  }
+</script>
+
+<HeaderProject projectid={project.id.toString()}/>
+
+<div class="container mx-auto p-5">
+  <table class="table w-full table-zebra">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Level</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each rooms as room}
+        <tr>
+          <td>{room.name}</td>
+          <td>{room.level}</td>
+          <td>
+            <div class="flex justify-end gap-3">
+              <button class="btn btn-error btn-xs" on:click={() => confirmDelete(room.id)}>Delete</button>
+            </div>
+          </td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+  {#if showRoomDeleteModal}
+    <div class="modal modal-open">
+      <div class="modal-box">
+        <h3 class="text-lg font-bold">Confirm Deletion</h3>
+        <p>Are you sure you want to delete this room?</p>
+        <div class="modal-action">
+          <button class="btn" on:click={() => showRoomDeleteModal = false}>Cancel</button>
+          <button class="btn btn-error" on:click={deleteRoom}>Delete</button>
+        </div>
+      </div>
+    </div>  
+  {/if}
+</div>
+  

--- a/src/routes/projects/[id]/rooms/+page.svelte
+++ b/src/routes/projects/[id]/rooms/+page.svelte
@@ -41,9 +41,12 @@
     }
   }
 
-  function navigateToRoom(pos: Vector3 | null) {
-    if (pos) {
-      goto(`/projects/${project.id.toString()}/viewer?posX=${pos.x}&posY=${pos.y}&posZ=${pos.z}`);
+  function navigateToRoom(point1: Vector3 | null, point2: Vector3 | null) {
+    if (point1 && point2) {
+      const x: number = (point1.x + point2.x) / 2
+      const y: number = (point1.y + point2.y) / 2
+      const z: number = (point1.z + point2.z) / 2
+      goto(`/projects/${project.id.toString()}/viewer?posX=${x}&posY=${y}&posZ=${z}`);
     }
   }
 </script>
@@ -66,8 +69,9 @@
           <td>{room.level}</td>
           <td>
             <div class="flex justify-end gap-3">
-              <a class="btn btn-xs" href="/projects/{project.id}/rooms/{room.id}">Details</a>
               <button class="btn btn-error btn-xs" on:click={() => confirmDelete(room.id)}>Delete</button>
+              <a class="btn btn-xs" href="/projects/{project.id}/rooms/{room.id}">Details</a>
+              <button class="btn btn-xs" on:click={() => navigateToRoom(room.point1, room.point2)}>Go to</button>
             </div>
           </td>
         </tr>

--- a/src/routes/projects/[id]/rooms/+page.svelte
+++ b/src/routes/projects/[id]/rooms/+page.svelte
@@ -41,7 +41,7 @@
     }
   }
 
-  function navigateToSensor(pos: Vector3 | null) {
+  function navigateToRoom(pos: Vector3 | null) {
     if (pos) {
       goto(`/projects/${project.id.toString()}/viewer?posX=${pos.x}&posY=${pos.y}&posZ=${pos.z}`);
     }
@@ -66,6 +66,7 @@
           <td>{room.level}</td>
           <td>
             <div class="flex justify-end gap-3">
+              <a class="btn btn-xs" href="/projects/{project.id}/rooms/{room.id}">Details</a>
               <button class="btn btn-error btn-xs" on:click={() => confirmDelete(room.id)}>Delete</button>
             </div>
           </td>

--- a/src/routes/projects/[id]/rooms/+page.ts
+++ b/src/routes/projects/[id]/rooms/+page.ts
@@ -1,0 +1,13 @@
+import type { Load } from '@sveltejs/kit';
+import { SitevisorService } from '../../../../services/sitevisor-service';
+
+export const ssr = false;
+
+export const load: Load = async ({ params }) => {
+	SitevisorService.checkPageRefresh();
+	const projectId = params.id ?? ''; 
+	const project = await SitevisorService.getProjectById(encodeURI(projectId));
+	return {
+	  project: project,
+	};
+};

--- a/src/routes/projects/[id]/rooms/[roomid]/+page.svelte
+++ b/src/routes/projects/[id]/rooms/[roomid]/+page.svelte
@@ -7,6 +7,7 @@
 	import type { IIssue } from "../../../../../services/sitevisor-types";
 	import IssuesTable from "$lib/components/IssuesTable.svelte";
 	import { onMount } from "svelte";
+	import type { Vector3 } from "three";
 	export let data: PageData;
 
     let room: IRoom = data.room;
@@ -49,6 +50,15 @@
         }
     }
 
+    function navigateToRoom(point1: Vector3 | null, point2: Vector3 | null) {
+    if (point1 && point2) {
+        const x: number = (point1.x + point2.x) / 2
+        const y: number = (point1.y + point2.y) / 2
+        const z: number = (point1.z + point2.z) / 2
+        goto(`/projects/${room.project}/viewer?posX=${x}&posY=${y}&posZ=${z}`);
+    }
+  }
+
 </script>
 
 <HeaderProject projectid={room.project.toString()}/>
@@ -59,6 +69,7 @@
             <h2 class="card-title">{room.name}</h2>
             <p>Level: {room.level}</p>
             <div class="card-actions justify-end">
+                <button class="btn" on:click={() => navigateToRoom(room.point1, room.point2)}>Go to</button>
                 <button class="btn btn-error" on:click={deleteRoom}>Delete</button>
             </div>
         </div>

--- a/src/routes/projects/[id]/rooms/[roomid]/+page.svelte
+++ b/src/routes/projects/[id]/rooms/[roomid]/+page.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import HeaderProject from "$lib/components/HeaderProject.svelte";
+    import type { PageData } from "./$types";
+    import { goto } from "$app/navigation";
+	import { SitevisorService } from "../../../../../services/sitevisor-service";
+    import type { IRoom } from "$lib/common/interfaces/IRoom";
+	import type { IIssue } from "../../../../../services/sitevisor-types";
+	import IssuesTable from "$lib/components/IssuesTable.svelte";
+	import { onMount } from "svelte";
+	export let data: PageData;
+
+    let room: IRoom = data.room;
+    let issues: IIssue[] = [];
+    let updatedName = room.name;
+
+    onMount(async () => {
+        await fetchIssues();
+    });
+
+    async function fetchIssues() {
+    try {
+      issues = await SitevisorService.getIssues({object_type: "room", object_id: room.id.toString()});
+    } catch (error) {
+      console.error("Failed to fetch issues:", error);
+    }
+  }
+
+    async function deleteRoom() {
+        try {
+            await SitevisorService.deleteRoom(room.id.toString());
+            goto(`/projects/${room.project}/rooms`);
+        } catch (error) {
+            console.log("Error trying to delete Room: " + room.id);
+        }
+    }
+
+    // Function to handle form submission
+    async function updateRoom() {
+        const updatedRoom: Partial<IRoom> = {
+            name: updatedName,
+        };
+
+        try {
+        await SitevisorService.updateRoom(room.id.toString(), updatedRoom);
+        room = { ...room, ...updatedRoom };
+        console.log("Room updated successfully");
+        } catch (error) {
+            console.error("Error updating Room:", error);
+        }
+    }
+
+</script>
+
+<HeaderProject projectid={room.project.toString()}/>
+
+<div class="container mx-auto p-5">
+    <div class="card bg-base-100 shadow-xl">
+        <div class="card-body">
+            <h2 class="card-title">{room.name}</h2>
+            <p>Level: {room.level}</p>
+            <div class="card-actions justify-end">
+                <button class="btn btn-error" on:click={deleteRoom}>Delete</button>
+            </div>
+        </div>
+    </div>
+    <div class="card bg-base-100 shadow-xl mt-4 w-1/2">
+        <div class="card-body">
+            <form on:submit|preventDefault={updateRoom} class="form">
+                <div class="form-control">
+                    <label class="label" for="roomName">Room Name</label>
+                    <input class="input input-bordered" type="text" id="roomName" bind:value={updatedName}>
+                </div>
+                <div class="card-actions justify-begin mt-4">
+                    <button type="submit" class="btn btn-primary">Update Room</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="card bg-base-100 mt-4 shadow-xl">
+        <div class="card-body">
+            <h2 class="card-title">Issues</h2>
+            <IssuesTable issues={issues} showTypeFilter={false} showTypeColumn={false}/>
+        </div>
+    </div>
+</div>

--- a/src/routes/projects/[id]/rooms/[roomid]/+page.ts
+++ b/src/routes/projects/[id]/rooms/[roomid]/+page.ts
@@ -1,0 +1,16 @@
+import type { Load } from "@sveltejs/kit";
+import { SitevisorService } from "../../../../../services/sitevisor-service";
+import type { IIssue } from "../../../../../services/sitevisor-types";
+import type { IRoom } from "$lib/common/interfaces/IRoom";
+export const ssr = false;
+
+export const load: Load = async ({ params }) => {
+  SitevisorService.checkPageRefresh();
+  const roomId: string = params.roomid ?? ''; 
+  const room: IRoom = await SitevisorService.getRoom(encodeURI(roomId));
+  const issues: IIssue[] = await SitevisorService.getIssues({object_type: "room", object_id: room.id})
+  return {
+    room: room,
+    issues: issues,
+  };
+};

--- a/src/routes/projects/[id]/sensors/+page.svelte
+++ b/src/routes/projects/[id]/sensors/+page.svelte
@@ -28,9 +28,9 @@
 
   async function fetchSensorsByType() {
     if (selectedSensorTypeId) {
-      sensors = await SitevisorService.getSensors(project.id.toString(), selectedSensorTypeId);
+      sensors = await SitevisorService.getSensors( {project_id: project.id.toString(), type: selectedSensorTypeId });
     } else {
-      sensors = await SitevisorService.getSensors(project.id.toString());
+      sensors = await SitevisorService.getSensors( {project_id: project.id.toString()} );
     }
   }
 

--- a/src/routes/projects/[id]/sensors/+page.svelte
+++ b/src/routes/projects/[id]/sensors/+page.svelte
@@ -1,119 +1,39 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
   import type { PageData } from './$types';
   import type { ISensor, ISensorType } from '../../../../lib/common/interfaces/ISensor';
   import type { IProject } from '../../../../services/sitevisor-types';
   import HeaderProject from '$lib/components/HeaderProject.svelte';
 	import { SitevisorService } from '../../../../services/sitevisor-service';
-	import type { Vector3 } from 'three';
+	import SensorTable from '$lib/components/SensorTable.svelte';
   export let data: PageData;
 
   let project: IProject = data.project;
   let sensors: ISensor[] = [];
   let sensorTypes: ISensorType[] = [];
-  let selectedSensorTypeId: string = ""
-
-  let pendingDeleteSensorId: string | null = null;
-  let showSensorDeleteModal: boolean = false;
 
   onMount(() => {
     fetchSensorTypes();
-    fetchSensorsByType();
+    fetchSensors();
   });
 
   async function fetchSensorTypes() {
     sensorTypes = await SitevisorService.getSensorTypes(project.id.toString());
   }
 
-  async function fetchSensorsByType() {
-    if (selectedSensorTypeId) {
-      sensors = await SitevisorService.getSensors( {project_id: project.id.toString(), type: selectedSensorTypeId });
-    } else {
-      sensors = await SitevisorService.getSensors( {project_id: project.id.toString()} );
-    }
+  async function fetchSensors() {
+    sensors = await SitevisorService.getSensors( {project_id: project.id.toString()} );
   }
 
-  $: fetchSensorsByType(), selectedSensorTypeId;
-
-  function confirmDelete(sensorId: string) {
-    pendingDeleteSensorId = sensorId;
-    showSensorDeleteModal = true;
-  }
-
-  async function deleteSensor() {
-    if (pendingDeleteSensorId) {
-      try {
-        await SitevisorService.deleteSensor(pendingDeleteSensorId);  
-        sensors = sensors.filter(s => s.id !== pendingDeleteSensorId);
-        showSensorDeleteModal = false;
-        pendingDeleteSensorId = null;
-      } catch (error) {
-        console.error("Error deleting sensor", error);
-      }
-    }
-  }
-
-  function navigateToSensor(pos: Vector3 | null) {
-    if (pos) {
-      goto(`/projects/${project.id.toString()}/viewer?posX=${pos.x}&posY=${pos.y}&posZ=${pos.z}`);
-    }
-  }
 </script>
 
 <HeaderProject projectid={project.id.toString()}/>
 
 <div class="container mx-auto p-5">
-  <div class="mb-4 flex items-center">
-    <label class="label mr-3" for="sensorTypeSelect">Sensor Type: </label>
-    <select id="sensorTypeSelect" class="select select-sm" bind:value={selectedSensorTypeId} required>
-      <option selected value="">All</option>
-      {#each sensorTypes as type}
-        <option value={type.id}>{type.name}</option>
-      {/each}
-    </select>
-  </div>
-  <table class="table w-full table-zebra">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Device ID</th>
-        <th>Type</th>
-        <th>Level</th>
-        <th>Position</th>
-        <th></th>
-      </tr>
-    </thead>
-    <tbody>
-      {#each sensors as sensor}
-        <tr>
-          <td>{sensor.name}</td>
-          <td>{sensor.device_id}</td>
-          <td>{sensor.type.name}</td>
-          <td>{sensor.level}</td>
-          <td>{sensor.position?.x.toFixed(2)}, {sensor.position?.y.toFixed(2)}, {sensor.position?.z.toFixed(2)}</td>
-          <td>
-            <div class="flex justify-end gap-3">
-              <button class="btn btn-error btn-xs" on:click={() => confirmDelete(sensor.id)}>Delete</button>
-              <a class="btn btn-xs" href="/projects/{project.id}/sensors/{sensor.id}">Details</a>
-              <button class="btn btn-xs" on:click={() => navigateToSensor(sensor.position)}>Go to</button>
-            </div>
-          </td>
-        </tr>
-      {/each}
-    </tbody>
-  </table>
-  {#if showSensorDeleteModal}
-    <div class="modal modal-open">
-      <div class="modal-box">
-        <h3 class="text-lg font-bold">Confirm Deletion</h3>
-        <p>Are you sure you want to delete this sensor?</p>
-        <div class="modal-action">
-          <button class="btn" on:click={() => showSensorDeleteModal = false}>Cancel</button>
-          <button class="btn btn-error" on:click={deleteSensor}>Delete</button>
-        </div>
-      </div>
-    </div>  
-  {/if}
+  <SensorTable
+    projectId={project.id.toString()}
+    sensors={sensors}
+    sensorTypes={sensorTypes}
+  />
 </div>
   

--- a/src/routes/projects/[id]/sensors/[sensorid]/+page.svelte
+++ b/src/routes/projects/[id]/sensors/[sensorid]/+page.svelte
@@ -7,6 +7,7 @@
 	import type { IIssue } from "../../../../../services/sitevisor-types";
 	import IssuesTable from "$lib/components/IssuesTable.svelte";
 	import { onMount } from "svelte";
+	import type { Vector3 } from "three";
 	export let data: PageData;
 
     let sensor: ISensor = data.sensor;
@@ -51,6 +52,12 @@
         }
     }
 
+    function navigateToSensor(pos: Vector3 | null) {
+        if (pos) {
+            goto(`/projects/${sensor.project}/viewer?posX=${pos.x}&posY=${pos.y}&posZ=${pos.z}`);
+        }
+  }
+
 </script>
 
 <HeaderProject projectid={sensor.project.toString()}/>
@@ -63,6 +70,7 @@
             <p>Level: {sensor.level}</p>
             <p>Type: {sensor.type.name}</p>
             <div class="card-actions justify-end">
+                <button class="btn" on:click={() => navigateToSensor(sensor.position)}>Go to</button>
                 <button class="btn btn-error" on:click={deleteSensor}>Delete</button>
             </div>
         </div>

--- a/src/routes/projects/[id]/sensors/[sensorid]/+page.svelte
+++ b/src/routes/projects/[id]/sensors/[sensorid]/+page.svelte
@@ -29,7 +29,7 @@
     async function deleteSensor() {
         try {
             await SitevisorService.deleteSensor(sensor.id.toString());
-            goto("/projects");
+            goto(`/projects/${sensor.project}/sensors`);
         } catch (error) {
             console.log("Error trying to delete Sensor: " + sensor.id);
         }

--- a/src/routes/projects/[id]/viewer/+page.svelte
+++ b/src/routes/projects/[id]/viewer/+page.svelte
@@ -179,7 +179,7 @@
 <div class="flex flex-col h-screen">
     <HeaderProject projectid={project.id.toString()}/>
     {#if selectedSensor}
-        <SensorDetails on:removeSensor={e => viewer.removeSensorFromScene(e.detail.device_id)} selectedSensor={selectedSensor}/>
+        <SensorDetails on:removeSensor={e => viewer.removeSensorFromScene(e.detail.device_id)} selectedSensor={selectedSensor} rooms={viewer.rooms}/>
     {/if}
     {#if selectedRoom}
         <RoomDetails on:removeRoom={e => viewer.removeRoomFromScene(e.detail.id)} selectedRoom={selectedRoom}/>

--- a/src/services/sitevisor-service.ts
+++ b/src/services/sitevisor-service.ts
@@ -60,6 +60,17 @@ export const SitevisorService = {
 		}
 	},
 
+	async updateRoom(id: string, updatedRoomData: Partial<IRoom>): Promise<void> {
+		try {
+			const url = `${this.baseUrl}/api/rooms/${id}/`;
+			await axios.patch(url, updatedRoomData);
+	
+			console.log("Room updated successfully");
+		} catch (error) {
+			console.error(`Error updating Room with id: ${id}`, error);
+		}
+	},
+
 	async getRooms(projectId: string): Promise<IRoom[]> {
 		try {
 			const response = await axios.get(this.baseUrl + `/api/rooms/?project_id=${projectId}`);

--- a/src/services/sitevisor-service.ts
+++ b/src/services/sitevisor-service.ts
@@ -132,13 +132,21 @@ export const SitevisorService = {
 		}
 	},
 
-	async getSensors(projectId: string, sensorTypeId?: string): Promise<ISensor[]> {
-		let url = `${this.baseUrl}/api/sensors/?project_id=${projectId}`;
-		if (sensorTypeId) {
-			url += `&type=${sensorTypeId}`;
-		}
-	
+	async getSensors(queryParams: Record<string, string | undefined>): Promise<ISensor[]> {
 		try {
+			let url = `${this.baseUrl}/api/sensors/`;
+	
+			const searchParams = new URLSearchParams();
+			Object.keys(queryParams).forEach(key => {
+				if (queryParams[key] !== undefined) {
+					searchParams.append(key, queryParams[key]!);
+				}
+			});
+	
+			if (Array.from(searchParams).length > 0) {
+				url += `?${searchParams.toString()}`;
+			}
+	
 			const response = await axios.get(url);
 			return response.data;
 		} catch (error) {


### PR DESCRIPTION
This PR adds Room related pages and enhancements to Room - Sensor relationship.

Upon creating a new Room or a new Sensor, their geometries are checked, and Sensors located within a Room are assigned to them automatically.

This allows to filter sensors by rooms.

Generally, more data interlinking has been added.

Refactored Sensor Table into a separate component.

Some improvements like querying sensors from the backend, brought by [this related PR](https://github.com/grzpiotrowski/sitevisor-backend/pull/26).

Closes #35 