### PR TITLE
Fix room selection after creating a sensor

### DIFF
--- a/src/lib/assets/Sensor.ts
+++ b/src/lib/assets/Sensor.ts
@@ -77,7 +77,10 @@ export class Sensor extends Point3D {
 
     for (const [room_id, room] of rooms) {
       room.geometry.computeBoundingBox();
-      if (room.geometry.boundingBox?.translate(room.position).containsPoint(sensorPosition)) {
+      // Creating a copy of the bounding box so it is not mutated with each check
+      const bbox = room.geometry.boundingBox?.clone()
+      bbox?.translate(room.position);
+      if (bbox?.containsPoint(sensorPosition)) {
         return room;
       }
     }


### PR DESCRIPTION
Fixes #65 

The bug was caused by applying translation to the bounding box when checking if sensor is inside a room.

Solved by creating a copy of the bounding box for the calculation and leaving the original bounding box of the Room not mutated.