### PR TITLE
Fix Room assignment on created Sensor

### DIFF
--- a/src/lib/assets/Room.ts
+++ b/src/lib/assets/Room.ts
@@ -102,7 +102,7 @@ export class Room extends Volume {
   public checkSensorsWithin(sensors: Map<string, Sensor>): Map<string, Sensor> {
     // Add a small height (skin width) for the detection purposes
     // Sensor is exactly on the floor of the room so it could happen that its not detected inside due to float
-    const skinWidth: number = 0.01;
+    const skinWidth: number = 0.001;
 
     const sensorsInRoom: Map<string, Sensor> = new Map();
     this.geometry.computeBoundingBox();

--- a/src/lib/assets/Sensor.ts
+++ b/src/lib/assets/Sensor.ts
@@ -71,7 +71,7 @@ export class Sensor extends Point3D {
   public checkIsInsideRoom(rooms: Map<string, Room>): Room | undefined {
     // Add a small height (skin width) for the detection purposes
     // Sensor is exactly on the floor of the room so it could happen that its not detected inside due to float
-    const skinWidth: number = 0.01;
+    const skinWidth: number = 0.001;
     const sensorPosition = this.position.clone();
     sensorPosition.setY(sensorPosition.y + skinWidth);
 

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -115,7 +115,6 @@ export class Viewer {
     window.addEventListener('resize', this.resize.bind(this));
     this.labelRenderer.domElement.addEventListener('mousemove', this.setPointerPosition.bind(this));
     this.labelRenderer.domElement.addEventListener('click', this.onCanvasClick.bind(this));
-    window.addEventListener('keypress', this.onKeyPress.bind(this));
 
     this.resize();
     this.animate();
@@ -435,14 +434,6 @@ export class Viewer {
       room.setGeometryMode(geometryMode);
     });
     this.heatmap.setGeometryMode(geometryMode, 3.0);
-  }
-
-  private onKeyPress(event: KeyboardEvent) {
-      if (event.key === 'n' || event.key === 'N') {
-        console.log("N key pressed");
-        // Key presses are active when a modal window is opened.
-        // This may cause potential bugs when user is typing into an input field.
-      }
   }
 
   private animate = () => {

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -267,6 +267,8 @@ export class Viewer {
                   const newRoom = this.objectFactory.createRoom(roomData);
                   if (newRoom) {
                     this.updateRoomContent(newRoom);
+                    const boxHelper = newRoom.boxHelper = new BoxHelper(newRoom, 0xffff00 );
+                    this.scene.add(boxHelper);
                   }
                 }
               }


### PR DESCRIPTION
This PR fixes a bug in functions checking which Room contains the Sensor and assigning them accordingly when in `2D` mode.

This was due to the sensor `skinWidth` parameter being larger than the `flatHeight` of a room.

Also the key press listener which was only used for debugging was deleted as it is no longer needed.

Another bug was also found when new Room was created due to `boxHelper` not being initialised.
A refactor would help to sort this out, but this needs to stay like that for now.

Ideally the `boxHelper` would not be added to the `scene` but rather added as a child to the `Room`.

Fixes #67 